### PR TITLE
fix: restrict CORS origins using CORS_ORIGINS env var

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -95,9 +95,14 @@ app = FastAPI(
 )
 
 # CORS configuration
+# CORS_ORIGINS: comma-separated list of allowed origins.
+# In development falls back to "*" when not set.
+_raw_cors = os.getenv("CORS_ORIGINS", "*" if IS_DEVELOPMENT else "")
+allow_origins = [o.strip() for o in _raw_cors.split(",") if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allow_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Problem
The backend had `allow_origins=["*"]` hardcoded, allowing all origins regardless of environment.

## Changes
- Read `CORS_ORIGINS` environment variable (comma-separated list of allowed origins)
- Falls back to `"*"` in development (`DEV`/`TEST`) when not set
- In production the value is injected by the infra Terraform config

## Notes
Android native HTTP clients (Flutter/Dart `http`) do not send an `Origin` header and bypass CORS entirely — no whitelisting needed for the Android app.