### PR TITLE
fix: replace datetime.UTC with timezone.utc in OTP and password reset routes

### DIFF
--- a/app/api/routes/authentication/login_otp.py
+++ b/app/api/routes/authentication/login_otp.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 import os
 import uuid
 
@@ -55,7 +55,7 @@ async def login_otp_request(request: LoginOTPRequest, db: Session = Depends(get_
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Account is banned"
         )
 
-    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    now = datetime.now(UTC).replace(tzinfo=None)
 
     # Cooldown: reject if a code was issued less than 60 seconds ago
     recent = (
@@ -122,7 +122,7 @@ def login_otp_verify(request: LoginVerifyRequest, db: Session = Depends(get_db))
             detail="Invalid or expired session",
         )
 
-    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    now = datetime.now(UTC).replace(tzinfo=None)
     if login_code.expires_at < now:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/app/api/routes/authentication/password_reset_confirm.py
+++ b/app/api/routes/authentication/password_reset_confirm.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
@@ -35,7 +35,7 @@ def password_reset_confirm(
             detail="Invalid or already used reset token",
         )
 
-    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    now = datetime.now(UTC).replace(tzinfo=None)
     if reset_token.expires_at < now:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/app/api/routes/authentication/password_reset_request.py
+++ b/app/api/routes/authentication/password_reset_request.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 import os
 import uuid
 
@@ -32,7 +32,7 @@ async def password_reset_request(
     user = db.query(Alumni).filter(Alumni.email == request.email).first()
 
     if user:
-        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        now = datetime.now(UTC).replace(tzinfo=None)
 
         # Cooldown: reject if a token was issued less than 60 seconds ago
         recent = (


### PR DESCRIPTION
## Bug

`datetime.UTC` is a **module-level** constant added in Python 3.11. It is **not** a class attribute of `datetime.datetime`.

All three new auth files import `from datetime import datetime` and then call `datetime.now(datetime.UTC)`, which tries to access `UTC` as a class attribute — raising:
```
AttributeError: type object 'datetime.datetime' has no attribute 'UTC'
```

This means **every** call to `POST /auth/login/otp/request`, `POST /auth/password-reset/request`, and `POST /auth/password-reset/confirm` returned HTTP 500 at runtime.

## Fix

Import `timezone` from `datetime` and use `datetime.now(timezone.utc)` in all three files.

## Files changed
- `app/api/routes/authentication/login_otp.py` (2 occurrences)
- `app/api/routes/authentication/password_reset_request.py` (1 occurrence)
- `app/api/routes/authentication/password_reset_confirm.py` (1 occurrence)

Closes #62