### PR TITLE
fix: register /profile/map route before /{user_id} to prevent shadowing

### DIFF
--- a/app/api/routes/profile/__init__.py
+++ b/app/api/routes/profile/__init__.py
@@ -8,5 +8,5 @@ router = APIRouter()
 # Include the sub-routers
 router.include_router(profile.router)
 router.include_router(get_profiles.router)
-router.include_router(get_other_profile.router)
 router.include_router(map.router)
+router.include_router(get_other_profile.router)


### PR DESCRIPTION
The dynamic route GET /profile/{user_id} was registered before the static route GET /profile/map, causing FastAPI to match /profile/map with user_id="map" and return 404 "User not found".

Move map.router to be included before get_other_profile.router so the static /map path takes precedence.

## Description

<!-- Describe your changes clearly. Include motivation and context. -->

Closes #

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️  Refactoring (no functional changes)
- [ ] 📝 Documentation update
- [ ] 🔧 CI / configuration

## How Has This Been Tested?

<!-- Describe what you tested and how to verify the change. -->

## Checklist

- [ ] Self-review completed
- [ ] Code follows existing style guidelines
- [ ] Tests added / updated where applicable
- [ ] All existing tests pass
- [ ] Documentation updated where applicable
- [ ] `ruff check .` passes with no errors
- [ ] New endpoints have corresponding Pydantic schemas
- [ ] Database changes include an Alembic migration
- [ ] No secrets or credentials committed
