### PR TITLE
refactor(auth): link-based verification, Telegram OTP login, profile Telegram verify

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -16,6 +16,7 @@ from app.models.login_code import LoginCode
 from app.models.password_reset_token import PasswordResetToken
 from app.models.settings import Setting
 from app.models.telegram import Feedback, Poll, TelegramUser
+from app.models.telegram_verify_token import TelegramVerifyToken
 from app.models.users import Admin, Alumni
 
 

--- a/alembic/versions/a3b4c5d6e7f8_auth_refactor.py
+++ b/alembic/versions/a3b4c5d6e7f8_auth_refactor.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = 'a3b4c5d6e7f8'
-down_revision: Union[str, None] = 'f1e2d3c4b5a6'
+down_revision: Union[str, None] = 'b1c2d3e4f5a6'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/a3b4c5d6e7f8_auth_refactor.py
+++ b/alembic/versions/a3b4c5d6e7f8_auth_refactor.py
@@ -1,0 +1,72 @@
+"""Add is_telegram_verified to alumni and refactor email_verifications for link-based flow; add telegram_verify_tokens table
+
+Revision ID: a3b4c5d6e7f8
+Revises: f1e2d3c4b5a6
+Create Date: 2026-03-09
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = 'a3b4c5d6e7f8'
+down_revision: Union[str, None] = 'f1e2d3c4b5a6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add is_telegram_verified to alumni
+    op.add_column(
+        'alumni',
+        sa.Column('is_telegram_verified', sa.Boolean(), nullable=False, server_default='false'),
+    )
+
+    # Add link-based verification columns to email_verifications
+    op.add_column(
+        'email_verifications',
+        sa.Column('verification_token', sa.String(), nullable=True),
+    )
+    op.add_column(
+        'email_verifications',
+        sa.Column('verification_token_expires', sa.DateTime(), nullable=True),
+    )
+    op.create_unique_constraint(
+        'uq_email_verifications_token', 'email_verifications', ['verification_token']
+    )
+    op.create_index(
+        'ix_email_verifications_token', 'email_verifications', ['verification_token']
+    )
+
+    # Make verification_code and verification_code_expires nullable (no longer required for link flow)
+    op.alter_column('email_verifications', 'verification_code', nullable=True)
+    op.alter_column('email_verifications', 'verification_code_expires', nullable=True)
+
+    # Create telegram_verify_tokens table
+    op.create_table(
+        'telegram_verify_tokens',
+        sa.Column('id', sa.String(), nullable=False),
+        sa.Column('alumni_id', sa.String(), sa.ForeignKey('alumni.id'), nullable=False),
+        sa.Column('token', sa.String(), nullable=False),
+        sa.Column('expires_at', sa.DateTime(), nullable=False),
+        sa.Column('used', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('token', name='uq_telegram_verify_tokens_token'),
+    )
+    op.create_index('ix_telegram_verify_tokens_token', 'telegram_verify_tokens', ['token'])
+    op.create_index('ix_telegram_verify_tokens_alumni_id', 'telegram_verify_tokens', ['alumni_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_telegram_verify_tokens_alumni_id', 'telegram_verify_tokens')
+    op.drop_index('ix_telegram_verify_tokens_token', 'telegram_verify_tokens')
+    op.drop_table('telegram_verify_tokens')
+
+    op.drop_index('ix_email_verifications_token', 'email_verifications')
+    op.drop_constraint('uq_email_verifications_token', 'email_verifications', type_='unique')
+    op.drop_column('email_verifications', 'verification_token_expires')
+    op.drop_column('email_verifications', 'verification_token')
+
+    op.drop_column('alumni', 'is_telegram_verified')

--- a/app/api/routes/authentication/__init__.py
+++ b/app/api/routes/authentication/__init__.py
@@ -4,11 +4,13 @@ from app.api.routes.authentication import (
     add_admin,
     login,
     login_otp,
+    login_telegram_otp,
     password_reset_confirm,
     password_reset_request,
     register,
     request_manual_verification,
     resend_verification,
+    telegram_verify,
     verify,
 )
 
@@ -22,6 +24,8 @@ router.include_router(resend_verification.router)
 router.include_router(request_manual_verification.router)
 router.include_router(login.router)
 router.include_router(login_otp.router)
+router.include_router(login_telegram_otp.router)
+router.include_router(telegram_verify.router)
 router.include_router(password_reset_request.router)
 router.include_router(password_reset_confirm.router)
 router.include_router(add_admin.router)

--- a/app/api/routes/authentication/login_telegram_otp.py
+++ b/app/api/routes/authentication/login_telegram_otp.py
@@ -8,14 +8,10 @@ from sqlalchemy.orm import Session
 from app.core.database import get_db
 from app.core.security import create_access_token
 from app.models.login_code import LoginCode
+from app.models.telegram import TelegramUser
 from app.models.users import Alumni
-from app.schemas.auth import (
-    LoginInitResponse,
-    LoginOTPRequest,
-    LoginVerifyRequest,
-    TokenResponse,
-)
-from app.services.email_service import send_login_code_email
+from app.schemas.auth import LoginInitResponse, TelegramLoginRequest, TelegramVerifyRequest, TokenResponse
+from app.services.telegram_bot import telegram_service
 from app.services.verification_service import generate_verification_code
 
 
@@ -26,12 +22,12 @@ OTP_COOLDOWN_SECONDS = 60
 OTP_MAX_ATTEMPTS = 5
 
 
-@router.post("/login/otp/request", response_model=LoginInitResponse)
-async def login_otp_request(request: LoginOTPRequest, db: Session = Depends(get_db)):
-    """OTP login step 1: validate email, send a 6-digit code to the university email.
+@router.post("/login/telegram/request", response_model=LoginInitResponse)
+async def login_telegram_request(request: TelegramLoginRequest, db: Session = Depends(get_db)):
+    """Telegram OTP login step 1: validate email, check telegram is verified, send 6-digit code via bot.
 
-    Returns a session_token for use in /login/otp/verify.
-    Rate-limited: one code per 60 seconds per account.
+    Requires the user to have verified their Telegram account via the profile page.
+    Returns a session_token for use in /login/telegram/verify.
     """
     user = db.query(Alumni).filter(Alumni.email == request.email).first()
 
@@ -51,9 +47,25 @@ async def login_otp_request(request: LoginOTPRequest, db: Session = Depends(get_
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Account is banned"
         )
 
+    if not user.is_telegram_verified:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Telegram not verified for this account. Please verify your Telegram account via your profile settings.",
+        )
+
+    tg_user = (
+        db.query(TelegramUser)
+        .filter(TelegramUser.alias == user.telegram_alias)
+        .first()
+    )
+    if not tg_user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Telegram bot not started. Please open the bot and send /start first.",
+        )
+
     now = datetime.now(UTC).replace(tzinfo=None)
 
-    # Cooldown: reject if a code was issued less than 60 seconds ago
     recent = (
         db.query(LoginCode)
         .filter(LoginCode.alumni_id == user.id, LoginCode.used.is_(False))
@@ -67,7 +79,6 @@ async def login_otp_request(request: LoginOTPRequest, db: Session = Depends(get_
             detail=f"Please wait {seconds_left} seconds before requesting a new code",
         )
 
-    # Invalidate previous unused codes
     db.query(LoginCode).filter(
         LoginCode.alumni_id == user.id, LoginCode.used.is_(False)
     ).delete()
@@ -87,31 +98,28 @@ async def login_otp_request(request: LoginOTPRequest, db: Session = Depends(get_
     ))
     db.commit()
 
-    email_sent = await send_login_code_email(
-        email=user.email,
+    sent = await telegram_service.send_login_code(
+        chat_id=tg_user.chat_id,
         first_name=user.first_name,
         code=code,
         expiry_minutes=LOGIN_CODE_EXPIRY_MINUTES,
     )
 
-    if not email_sent:
+    if not sent:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to send login code. Please try again later.",
+            detail="Failed to send Telegram code. Please try again later.",
         )
 
     return LoginInitResponse(
         session_token=session_token,
-        message=f"A verification code has been sent to {request.email}",
+        message="A verification code has been sent to your Telegram account",
     )
 
 
-@router.post("/login/otp/verify", response_model=TokenResponse)
-def login_otp_verify(request: LoginVerifyRequest, db: Session = Depends(get_db)):
-    """OTP login step 2: submit session_token + 6-digit code.
-
-    Invalidated after 5 wrong attempts or expiry.
-    """
+@router.post("/login/telegram/verify", response_model=TokenResponse)
+def login_telegram_verify(request: TelegramVerifyRequest, db: Session = Depends(get_db)):
+    """Telegram OTP login step 2: submit session_token + 6-digit code."""
     login_code = (
         db.query(LoginCode)
         .filter(LoginCode.session_token == request.session_token)

--- a/app/api/routes/authentication/login_telegram_otp.py
+++ b/app/api/routes/authentication/login_telegram_otp.py
@@ -1,6 +1,6 @@
-from datetime import UTC, datetime, timedelta
 import os
 import uuid
+from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session

--- a/app/api/routes/authentication/login_telegram_otp.py
+++ b/app/api/routes/authentication/login_telegram_otp.py
@@ -1,6 +1,6 @@
+from datetime import UTC, datetime, timedelta
 import os
 import uuid
-from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
@@ -10,7 +10,12 @@ from app.core.security import create_access_token
 from app.models.login_code import LoginCode
 from app.models.telegram import TelegramUser
 from app.models.users import Alumni
-from app.schemas.auth import LoginInitResponse, TelegramLoginRequest, TelegramVerifyRequest, TokenResponse
+from app.schemas.auth import (
+    LoginInitResponse,
+    TelegramLoginRequest,
+    TelegramVerifyRequest,
+    TokenResponse,
+)
 from app.services.telegram_bot import telegram_service
 from app.services.verification_service import generate_verification_code
 

--- a/app/api/routes/authentication/register.py
+++ b/app/api/routes/authentication/register.py
@@ -13,7 +13,10 @@ from app.services.email_service import (
     send_verification_link_email,
 )
 from app.services.notification_service import NotificationService
-from app.services.verification_service import create_link_verification_record, create_verification_record
+from app.services.verification_service import (
+    create_link_verification_record,
+    create_verification_record,
+)
 
 
 # Get logger for this module

--- a/app/api/routes/authentication/register.py
+++ b/app/api/routes/authentication/register.py
@@ -70,7 +70,7 @@ async def register(
     if email_allowed and not request.manual_verification:
         # Auto verification: send confirmation link
         _, token = create_link_verification_record(db, new_user.id)
-        verify_url = f"{BACKEND_URL}/auth/verify?token={token}"
+        verify_url = f"{BACKEND_URL}/api/v1/auth/verify?token={token}"
         logger.info(f"Sending verification link to {new_user.email}")
         email_sent = await send_verification_link_email(
             new_user.email, new_user.first_name, verify_url

--- a/app/api/routes/authentication/register.py
+++ b/app/api/routes/authentication/register.py
@@ -10,15 +10,16 @@ from app.schemas.auth import RegisterRequest
 from app.services.email_hash_service import is_email_allowed
 from app.services.email_service import (
     send_manual_verification_notification,
-    send_verification_email,
+    send_verification_link_email,
 )
 from app.services.notification_service import NotificationService
-from app.services.verification_service import create_verification_record
+from app.services.verification_service import create_link_verification_record, create_verification_record
 
 
 # Get logger for this module
 logger = logging.getLogger("iu_alumni.auth.register")
 
+BACKEND_URL = __import__("os").getenv("BACKEND_URL", "")
 
 router = APIRouter()
 
@@ -30,28 +31,18 @@ async def register(
     db: Session = Depends(get_db),
 ):
     """
-    Register a new alumni user with email verification.
+    Register a new alumni user.
 
-    Logic:
-    Case 1 - Email is in allowed list:
-    - If manual_verification=False: send verification code to email
-    - If manual_verification=True: request manual verification from admin
-
-    Case 2 - Email is NOT in allowed list:
-    - Regardless of manual_verification choice: request manual verification from admin
-    - Admin is notified that user is not a graduate (email not in list)
-    - No verification code is sent
-
-    User must verify email with code OR get admin approval to complete registration
+    - Email in allowed list + auto verify: send a confirmation link to the user's email.
+    - Email in allowed list + manual_verification: notify admins, pending approval.
+    - Email NOT in allowed list: always route to manual verification regardless of flag.
     """
-    # Check if email already exists
     existing_user = db.query(Alumni).filter(Alumni.email == request.email).first()
     if existing_user:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Email already registered"
         )
 
-    # Create new alumni user (unverified)
     new_user = Alumni(
         id=get_random_token(),
         email=request.email,
@@ -68,97 +59,63 @@ async def register(
     db.commit()
     db.refresh(new_user)
 
-    # Check if email is in the allowed list
     logger.info(f"Checking if email {request.email} is in the allowed list")
     email_allowed = is_email_allowed(db, request.email)
 
-    # Create verification record
-    logger.info(f"Creating verification record for {new_user.email}")
-    verification = create_verification_record(
-        db=db,
-        alumni_id=new_user.id,
-        manual_verification=request.manual_verification or not email_allowed,
-    )
-    logger.info(f"Verification record created: {verification}")
+    alias_display = f"@{new_user.telegram_alias.lstrip('@')}" if new_user.telegram_alias else "Not provided"
 
-    # Case 1: Email is in allowed list
-    if email_allowed:
-        if request.manual_verification:
-            # User requested manual verification even though email is allowed
-            logger.info(
-                f"User {request.email} requested manual verification (email is in allowed list)"
-            )
-
-            # Send Telegram notification to admins
-            alias_display = f"@{new_user.telegram_alias.lstrip('@')}" if new_user.telegram_alias else "Not provided"
-            admin_message = (
-                f"🔔 Manual Verification Request\n\n"
-                f"Name: {new_user.first_name} {new_user.last_name}\n"
-                f"Email: {new_user.email}\n"
-                f"Telegram Alias: {alias_display}\n\n"
-                f"You can verify this account via the admin dashboard."
-            )
-            background_tasks.add_task(NotificationService.send_admin_notification, admin_message)
-
-            # Also send email notifications to admins as backup
-            admins = db.query(Admin).all()
-            for admin in admins:
-                background_tasks.add_task(
-                    send_manual_verification_notification,
-                    admin.email,
-                    new_user.email,
-                    f"{new_user.first_name} {new_user.last_name}",
-                )
-
-            return {
-                "message": "Registration successful. Your account is pending manual verification by an administrator.",
-                "email": new_user.email,
-            }
-        # Send verification code to email
-        logger.info(
-            f"Sending verification email to {new_user.email} (email is in allowed list)"
-        )
-        email_sent = await send_verification_email(
-            new_user.email, new_user.first_name, verification.verification_code
+    if email_allowed and not request.manual_verification:
+        # Auto verification: send confirmation link
+        _, token = create_link_verification_record(db, new_user.id)
+        verify_url = f"{BACKEND_URL}/auth/verify?token={token}"
+        logger.info(f"Sending verification link to {new_user.email}")
+        email_sent = await send_verification_link_email(
+            new_user.email, new_user.first_name, verify_url
         )
         if not email_sent:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to send verification email. Please try again later.",
             )
-        logger.info(f"Verification email sent to {new_user.email}")
         return {
-            "message": "Registration successful. Please check your email for verification code.",
+            "message": "Registration successful. Please check your email for a confirmation link.",
             "email": new_user.email,
         }
 
-    # Case 2: Email is NOT in allowed list
-    logger.info(
-        f"Email {request.email} is NOT in allowed list - requesting manual verification"
+    # Manual verification path (user requested it, or email not in allowed list)
+    create_verification_record(
+        db=db,
+        alumni_id=new_user.id,
+        manual_verification=True,
     )
 
-    # Send Telegram notification to admins with note about non-graduate status
-    alias_display = f"@{new_user.telegram_alias.lstrip('@')}" if new_user.telegram_alias else "Not provided"
+    not_graduate_note = "" if email_allowed else " (NOT A GRADUATE - email not in allowed list)"
     admin_message = (
         f"🔔 Manual Verification Request\n\n"
-        f"Name: {new_user.first_name} {new_user.last_name} (NOT A GRADUATE - email not in allowed list)\n"
+        f"Name: {new_user.first_name} {new_user.last_name}{not_graduate_note}\n"
         f"Email: {new_user.email}\n"
         f"Telegram Alias: {alias_display}\n\n"
         f"You can verify this account via the admin dashboard."
     )
     background_tasks.add_task(NotificationService.send_admin_notification, admin_message)
 
-    # Also send email notifications to admins as backup
     admins = db.query(Admin).all()
     for admin in admins:
         background_tasks.add_task(
             send_manual_verification_notification,
             admin.email,
             new_user.email,
-            f"{new_user.first_name} {new_user.last_name} (NOT A GRADUATE - email not in allowed list)",
+            f"{new_user.first_name} {new_user.last_name}{not_graduate_note}",
         )
 
+    if not email_allowed:
+        return {
+            "message": "Registration successful. Your email is not in our graduates list. Your account is pending manual verification by an administrator.",
+            "email": new_user.email,
+        }
+
     return {
-        "message": "Registration successful. Your email is not in our graduates list. Your account is pending manual verification by an administrator.",
+        "message": "Registration successful. Your account is pending manual verification by an administrator.",
         "email": new_user.email,
     }
+

--- a/app/api/routes/authentication/resend_verification.py
+++ b/app/api/routes/authentication/resend_verification.py
@@ -1,54 +1,51 @@
+import os
+
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.models.users import Alumni
 from app.schemas.auth import ResendVerificationRequest
-from app.services.email_service import send_verification_email
+from app.services.email_service import send_verification_link_email
 from app.services.verification_service import (
     can_resend_verification,
-    create_verification_record,
+    create_link_verification_record,
 )
 
+BACKEND_URL = os.getenv("BACKEND_URL", "")
 
 router = APIRouter()
 
 
 @router.post("/resend-verification", status_code=status.HTTP_200_OK)
-async def resend_verification_code(
+async def resend_verification_link(
     request: ResendVerificationRequest,
     background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
 ):
     """
-    Resend verification code to user's email
-
-    Rate limited to once per 60 seconds
+    Resend email verification link. Rate-limited to once per 60 seconds.
     """
-    # Check if user can request a new code
     can_resend, message, _alumni_id = can_resend_verification(db, request.email)
 
     if not can_resend:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message)
 
-    # Get user details
     user = db.query(Alumni).filter(Alumni.email == request.email).first()
     if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         )
 
-    # Create/update verification record with new code
-    verification = create_verification_record(
-        db=db, alumni_id=user.id, manual_verification=False
-    )
+    _, token = create_link_verification_record(db, user.id)
+    verify_url = f"{BACKEND_URL}/auth/verify?token={token}"
 
-    # Send new verification email
     background_tasks.add_task(
-        send_verification_email,
+        send_verification_link_email,
         user.email,
         user.first_name,
-        verification.verification_code,
+        verify_url,
     )
 
-    return {"message": "New verification code sent to your email", "email": user.email}
+    return {"message": "A new verification link has been sent to your email", "email": user.email}
+

--- a/app/api/routes/authentication/resend_verification.py
+++ b/app/api/routes/authentication/resend_verification.py
@@ -12,6 +12,7 @@ from app.services.verification_service import (
     create_link_verification_record,
 )
 
+
 BACKEND_URL = os.getenv("BACKEND_URL", "")
 
 router = APIRouter()

--- a/app/api/routes/authentication/resend_verification.py
+++ b/app/api/routes/authentication/resend_verification.py
@@ -39,7 +39,7 @@ async def resend_verification_link(
         )
 
     _, token = create_link_verification_record(db, user.id)
-    verify_url = f"{BACKEND_URL}/auth/verify?token={token}"
+    verify_url = f"{BACKEND_URL}/api/v1/auth/verify?token={token}"
 
     background_tasks.add_task(
         send_verification_link_email,

--- a/app/api/routes/authentication/telegram_verify.py
+++ b/app/api/routes/authentication/telegram_verify.py
@@ -1,0 +1,186 @@
+import os
+import secrets
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import HTMLResponse
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import get_current_user, get_random_token
+from app.models.telegram import TelegramUser
+from app.models.telegram_verify_token import TelegramVerifyToken
+from app.models.users import Alumni
+from app.schemas.auth import TelegramVerifyRequestResponse
+from app.services.email_service import send_telegram_verification_email
+
+
+router = APIRouter()
+
+BACKEND_URL = os.getenv("BACKEND_URL", "")
+TELEGRAM_VERIFY_EXPIRY_HOURS = int(os.getenv("TELEGRAM_VERIFY_EXPIRY_HOURS", "24"))
+MINI_APP_URL = os.getenv("MINI_APP_URL", "")
+
+
+@router.post("/telegram/verify/request", response_model=TelegramVerifyRequestResponse)
+async def telegram_verify_request(
+    db: Session = Depends(get_db),
+    current_user: Alumni = Depends(get_current_user),
+):
+    """
+    Request Telegram account verification (profile page).
+
+    Checks that:
+    - User has a telegram_alias set.
+    - The alias has started the bot (TelegramUser record exists).
+
+    Sends a verification link to the user's email. When clicked, sets is_telegram_verified=True.
+    """
+    if not isinstance(current_user, Alumni):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only alumni accounts can verify Telegram",
+        )
+
+    if not current_user.telegram_alias:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Please set a Telegram alias in your profile first",
+        )
+
+    tg_user = (
+        db.query(TelegramUser)
+        .filter(TelegramUser.alias == current_user.telegram_alias)
+        .first()
+    )
+    if not tg_user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Telegram bot not started. Please open @IU_Alumni_Notification_Bot "
+                f"and send /start, then try again."
+            ),
+        )
+
+    now = datetime.now(UTC).replace(tzinfo=None)
+
+    # Invalidate any previous unused tokens for this user
+    db.query(TelegramVerifyToken).filter(
+        TelegramVerifyToken.alumni_id == current_user.id,
+        TelegramVerifyToken.used.is_(False),
+    ).delete()
+
+    token = secrets.token_urlsafe(32)
+    db.add(TelegramVerifyToken(
+        id=get_random_token(),
+        alumni_id=current_user.id,
+        token=token,
+        expires_at=now + timedelta(hours=TELEGRAM_VERIFY_EXPIRY_HOURS),
+        used=False,
+        created_at=now,
+    ))
+    db.commit()
+
+    verify_url = f"{BACKEND_URL}/auth/telegram/verify?token={token}"
+    email_sent = await send_telegram_verification_email(
+        email=current_user.email,
+        first_name=current_user.first_name,
+        telegram_alias=current_user.telegram_alias,
+        verify_link=verify_url,
+        expiry_hours=TELEGRAM_VERIFY_EXPIRY_HOURS,
+    )
+
+    if not email_sent:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to send verification email. Please try again later.",
+        )
+
+    return TelegramVerifyRequestResponse(
+        message="A verification link has been sent to your email. Click it to confirm your Telegram account."
+    )
+
+
+@router.get("/telegram/verify", response_class=HTMLResponse)
+def telegram_verify_confirm(
+    token: str,
+    db: Session = Depends(get_db),
+):
+    """
+    Confirm Telegram account via link (opened in browser from email).
+    Sets is_telegram_verified=True on the user's account.
+    """
+    record = (
+        db.query(TelegramVerifyToken)
+        .filter(TelegramVerifyToken.token == token)
+        .first()
+    )
+
+    if not record or record.used:
+        return HTMLResponse(
+            content=_render_page(False, "Invalid or already used verification link."),
+            status_code=400,
+        )
+
+    now = datetime.now(UTC).replace(tzinfo=None)
+    if record.expires_at < now:
+        return HTMLResponse(
+            content=_render_page(False, "This verification link has expired. Please request a new one from the app."),
+            status_code=400,
+        )
+
+    user = db.query(Alumni).filter(Alumni.id == record.alumni_id).first()
+    if not user:
+        return HTMLResponse(
+            content=_render_page(False, "User not found."),
+            status_code=404,
+        )
+
+    user.is_telegram_verified = True
+    record.used = True
+    db.commit()
+
+    alias = f"@{user.telegram_alias}" if user.telegram_alias else ""
+    return HTMLResponse(
+        content=_render_page(
+            True,
+            f"Telegram {alias} has been verified for your account, {user.first_name}! "
+            f"You can now use Telegram to log in to IU Alumni.",
+        )
+    )
+
+
+def _render_page(success: bool, message: str) -> str:
+    color = "#2CA5E0" if success else "#ef4444"
+    icon = "✅" if success else "❌"
+    title = "Telegram Verified" if success else "Verification Failed"
+    app_link = f'<p style="margin-top:20px"><a href="{MINI_APP_URL}" style="color:#2CA5E0;font-weight:600;">Open the IU Alumni App</a></p>' if success and MINI_APP_URL else ""
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>{title} — IU Alumni</title>
+  <style>
+    body{{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+         background:#f9fafb;display:flex;align-items:center;justify-content:center;
+         min-height:100vh;margin:0;padding:20px;box-sizing:border-box;}}
+    .card{{background:#fff;border-radius:16px;padding:48px 40px;max-width:420px;
+           width:100%;text-align:center;box-shadow:0 4px 24px rgba(0,0,0,.08);}}
+    .icon{{font-size:56px;margin-bottom:16px;}}
+    h1{{font-size:24px;font-weight:700;color:#111827;margin:0 0 12px;}}
+    p{{color:#6b7280;font-size:15px;line-height:1.6;margin:0;}}
+    .badge{{display:inline-block;margin-top:24px;padding:8px 20px;border-radius:8px;
+            background:{color};color:#fff;font-weight:600;font-size:14px;}}
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">{icon}</div>
+    <h1>{title}</h1>
+    <p>{message}</p>
+    <div class="badge">IU Alumni Platform</div>
+    {app_link}
+  </div>
+</body>
+</html>"""

--- a/app/api/routes/authentication/telegram_verify.py
+++ b/app/api/routes/authentication/telegram_verify.py
@@ -2,6 +2,7 @@ import os
 import secrets
 from datetime import UTC, datetime, timedelta
 
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
@@ -57,8 +58,8 @@ async def telegram_verify_request(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=(
-                f"Telegram bot not started. Please open @IU_Alumni_Notification_Bot "
-                f"and send /start, then try again."
+                "Telegram bot not started. Please open @IU_Alumni_Notification_Bot "
+                "and send /start, then try again."
             ),
         )
 
@@ -108,6 +109,7 @@ def telegram_verify_confirm(
 ):
     """
     Confirm Telegram account via link (opened in browser from email).
+
     Sets is_telegram_verified=True on the user's account.
     """
     record = (

--- a/app/api/routes/authentication/telegram_verify.py
+++ b/app/api/routes/authentication/telegram_verify.py
@@ -81,7 +81,7 @@ async def telegram_verify_request(
     ))
     db.commit()
 
-    verify_url = f"{BACKEND_URL}/auth/telegram/verify?token={token}"
+    verify_url = f"{BACKEND_URL}/api/v1/auth/telegram/verify?token={token}"
     email_sent = await send_telegram_verification_email(
         email=current_user.email,
         first_name=current_user.first_name,

--- a/app/api/routes/authentication/telegram_verify.py
+++ b/app/api/routes/authentication/telegram_verify.py
@@ -1,7 +1,6 @@
+from datetime import UTC, datetime, timedelta
 import os
 import secrets
-from datetime import UTC, datetime, timedelta
-
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import HTMLResponse

--- a/app/api/routes/authentication/verify.py
+++ b/app/api/routes/authentication/verify.py
@@ -11,6 +11,7 @@ from app.schemas.auth import TokenResponse, VerifyEmailRequest
 from app.services.email_service import send_verification_success_email
 from app.services.verification_service import verify_by_token, verify_code
 
+
 MINI_APP_URL = os.getenv("MINI_APP_URL", "")
 
 router = APIRouter()

--- a/app/api/routes/authentication/verify.py
+++ b/app/api/routes/authentication/verify.py
@@ -1,6 +1,6 @@
 import os
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
 
@@ -24,6 +24,7 @@ async def verify_email_link(
 ):
     """
     Verify email via a link token (sent during registration).
+
     Opened in the user's browser from the email confirmation link.
     """
     success, message, alumni = verify_by_token(db, token)

--- a/app/api/routes/authentication/verify.py
+++ b/app/api/routes/authentication/verify.py
@@ -1,4 +1,7 @@
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+import os
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
+from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
@@ -6,28 +9,57 @@ from app.core.security import create_access_token
 from app.models.users import Alumni
 from app.schemas.auth import TokenResponse, VerifyEmailRequest
 from app.services.email_service import send_verification_success_email
-from app.services.verification_service import verify_code
+from app.services.verification_service import verify_by_token, verify_code
 
+MINI_APP_URL = os.getenv("MINI_APP_URL", "")
 
 router = APIRouter()
 
 
+@router.get("/verify", response_class=HTMLResponse)
+async def verify_email_link(
+    token: str,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+):
+    """
+    Verify email via a link token (sent during registration).
+    Opened in the user's browser from the email confirmation link.
+    """
+    success, message, alumni = verify_by_token(db, token)
+
+    if not success:
+        return HTMLResponse(
+            content=_render_result_page(success=False, message=message),
+            status_code=400,
+        )
+
+    background_tasks.add_task(
+        send_verification_success_email, alumni.email, alumni.first_name
+    )
+
+    return HTMLResponse(
+        content=_render_result_page(
+            success=True,
+            message=f"Your email has been verified, {alumni.first_name}! You can now log in to the IU Alumni app.",
+        )
+    )
+
+
 @router.post("/verify", response_model=TokenResponse)
-async def verify_email(
+async def verify_email_code(
     request: VerifyEmailRequest,
     background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
 ):
     """
-    Verify email with verification code and return access token
+    Verify email with a verification code (legacy / admin-path only).
     """
-    # Verify the code
     success, message = verify_code(db, request.email, request.verification_code)
 
     if not success:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message)
 
-    # Get the verified user
     user = db.query(Alumni).filter(Alumni.email == request.email).first()
 
     if not user:
@@ -35,13 +67,47 @@ async def verify_email(
             status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         )
 
-    # Send success email
     background_tasks.add_task(
         send_verification_success_email, user.email, user.first_name
     )
 
-    # Generate access token
     user_data = {"sub": user.email, "user_id": user.id, "user_type": "alumni"}
     access_token = create_access_token(data=user_data)
 
     return {"access_token": access_token, "token_type": "bearer"}
+
+
+def _render_result_page(success: bool, message: str) -> str:
+    color = "#40BA21" if success else "#ef4444"
+    icon = "✅" if success else "❌"
+    title = "Email Verified" if success else "Verification Failed"
+    app_link = f'<p style="margin-top:20px"><a href="{MINI_APP_URL}" style="color:#40BA21;font-weight:600;">Open the IU Alumni App</a></p>' if success and MINI_APP_URL else ""
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>{title} — IU Alumni</title>
+  <style>
+    body{{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+         background:#f9fafb;display:flex;align-items:center;justify-content:center;
+         min-height:100vh;margin:0;padding:20px;box-sizing:border-box;}}
+    .card{{background:#fff;border-radius:16px;padding:48px 40px;max-width:420px;
+           width:100%;text-align:center;box-shadow:0 4px 24px rgba(0,0,0,.08);}}
+    .icon{{font-size:56px;margin-bottom:16px;}}
+    h1{{font-size:24px;font-weight:700;color:#111827;margin:0 0 12px;}}
+    p{{color:#6b7280;font-size:15px;line-height:1.6;margin:0;}}
+    .badge{{display:inline-block;margin-top:24px;padding:8px 20px;border-radius:8px;
+            background:{color};color:#fff;font-weight:600;font-size:14px;}}
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">{icon}</div>
+    <h1>{title}</h1>
+    <p>{message}</p>
+    <div class="badge">IU Alumni Platform</div>
+    {app_link}
+  </div>
+</body>
+</html>"""

--- a/app/api/routes/profile/profile.py
+++ b/app/api/routes/profile/profile.py
@@ -57,7 +57,10 @@ def update_profile(
         current_user.biography = profile_data.biography
 
     if profile_data.telegram_alias is not None:
-        current_user.telegram_alias = profile_data.telegram_alias
+        new_alias = profile_data.telegram_alias
+        if new_alias != current_user.telegram_alias:
+            current_user.telegram_alias = new_alias
+            current_user.is_telegram_verified = False
 
     if profile_data.avatar is not None:
         current_user.avatar = profile_data.avatar

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ import os
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.routing import APIRouter
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.api.routes.admin import router as admin_router
@@ -108,11 +109,13 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.include_router(auth_router, prefix="/auth", tags=["Authentication"])
-app.include_router(profile_router, prefix="/profile", tags=["Profile"])
-app.include_router(events_router, prefix="/events", tags=["Events"])
-app.include_router(admin_router, prefix="/admin", tags=["Admin"])
-app.include_router(cities_router, prefix="/cities", tags=["Cities"])
+api_v1 = APIRouter(prefix="/api/v1")
+api_v1.include_router(auth_router, prefix="/auth", tags=["Authentication"])
+api_v1.include_router(profile_router, prefix="/profile", tags=["Profile"])
+api_v1.include_router(events_router, prefix="/events", tags=["Events"])
+api_v1.include_router(admin_router, prefix="/admin", tags=["Admin"])
+api_v1.include_router(cities_router, prefix="/cities", tags=["Cities"])
+app.include_router(api_v1)
 app.include_router(telegram_router, tags=["Telegram"])
 
 Instrumentator().instrument(app).expose(app)

--- a/app/models/email_verification.py
+++ b/app/models/email_verification.py
@@ -9,8 +9,10 @@ class EmailVerification(Base):
 
     id = Column(String, primary_key=True)
     alumni_id = Column(String, ForeignKey("alumni.id"), unique=True, nullable=False)
-    verification_code = Column(String, nullable=False)
-    verification_code_expires = Column(DateTime, nullable=False)
+    verification_code = Column(String, nullable=True)
+    verification_code_expires = Column(DateTime, nullable=True)
+    verification_token = Column(String, nullable=True, unique=True, index=True)
+    verification_token_expires = Column(DateTime, nullable=True)
     verification_requested_at = Column(DateTime, nullable=False)
     manual_verification_requested = Column(Boolean, default=False)
     verified_at = Column(DateTime, nullable=True)

--- a/app/models/telegram_verify_token.py
+++ b/app/models/telegram_verify_token.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, String
+from sqlalchemy.orm import relationship
+
+from app.core.database import Base
+
+
+class TelegramVerifyToken(Base):
+    """Token for link-based Telegram account verification (sent via email)."""
+
+    __tablename__ = "telegram_verify_tokens"
+
+    id = Column(String, primary_key=True)
+    alumni_id = Column(String, ForeignKey("alumni.id"), nullable=False)
+    token = Column(String, unique=True, nullable=False, index=True)
+    expires_at = Column(DateTime, nullable=False)
+    used = Column(Boolean, default=False, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    alumni = relationship("Alumni")

--- a/app/models/users.py
+++ b/app/models/users.py
@@ -17,6 +17,7 @@ class Alumni(Base):
     biography = Column(String)
     show_location = Column(Boolean, default=False)
     telegram_alias = Column(String)
+    is_telegram_verified = Column(Boolean, default=False, nullable=False)
     avatar = Column(String)
     is_verified = Column(Boolean, default=False, index=True)
     is_banned = Column(Boolean, default=False, index=True)

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,4 +1,5 @@
 import re
+from typing import Optional
 
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
@@ -46,7 +47,7 @@ class RegisterRequest(BaseModel):
     last_name: str = Field(..., min_length=1, max_length=100)
     graduation_year: str
     email: EmailStr
-    telegram_alias: str = Field(..., min_length=3, max_length=50)
+    telegram_alias: Optional[str] = Field(None, min_length=3, max_length=50)
     password: str = Field(..., min_length=8)
     manual_verification: bool = False
 
@@ -61,10 +62,10 @@ class RegisterRequest(BaseModel):
 
     @field_validator("telegram_alias")
     def validate_telegram_alias(cls, v):
-        # Remove @ if present at the beginning
+        if v is None:
+            return v
         if v.startswith("@"):
             v = v[1:]
-        # Validate Telegram username format
         if not re.match(r"^[a-zA-Z0-9_]{3,32}$", v):
             raise ValueError("Invalid Telegram username format")
         return v
@@ -90,3 +91,19 @@ class ResendVerificationRequest(BaseModel):
                 "Email must be an Innopolis email (@innopolis.university or @innopolis.ru)"
             )
         return v
+
+
+# Telegram OTP login schemas
+class TelegramLoginRequest(BaseModel):
+    email: EmailStr
+
+
+class TelegramVerifyRequest(BaseModel):
+    session_token: str
+    code: str = Field(..., pattern=r"^\d{6}$")
+
+
+# Telegram account verification schemas (profile)
+class TelegramVerifyRequestResponse(BaseModel):
+    message: str
+

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
@@ -47,7 +46,7 @@ class RegisterRequest(BaseModel):
     last_name: str = Field(..., min_length=1, max_length=100)
     graduation_year: str
     email: EmailStr
-    telegram_alias: Optional[str] = Field(None, min_length=3, max_length=50)
+    telegram_alias: str | None = Field(None, min_length=3, max_length=50)
     password: str = Field(..., min_length=8)
     manual_verification: bool = False
 

--- a/app/schemas/profile.py
+++ b/app/schemas/profile.py
@@ -14,6 +14,7 @@ class ProfileResponse(BaseModel):
     biography: str | None = None
     show_location: bool = False
     telegram_alias: str | None = None
+    is_telegram_verified: bool = False
     avatar: str | None = None
 
     class Config:

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -172,3 +172,49 @@ async def send_verification_success_email(email: EmailStr, first_name: str) -> b
         logger.exception("Failed to send verification success email to %s", email)
         return False
 
+
+async def send_verification_link_email(
+    email: EmailStr, first_name: str, verify_link: str, expiry_hours: int = 24
+) -> bool:
+    """Send link-based registration email verification."""
+    try:
+        message = MessageSchema(
+            subject="Verify your IU Alumni account",
+            recipients=[email],
+            template_body={
+                "first_name": first_name,
+                "verify_link": verify_link,
+                "expiry_hours": expiry_hours,
+            },
+            subtype=MessageType.html,
+        )
+        logger.info("Sending verification link email to %s", email)
+        await fm.send_message(message, template_name="verification_link.html")
+        return True
+    except Exception:
+        logger.exception("Failed to send verification link email to %s", email)
+        return False
+
+
+async def send_telegram_verification_email(
+    email: EmailStr, first_name: str, telegram_alias: str, verify_link: str, expiry_hours: int = 24
+) -> bool:
+    """Send link-based Telegram account verification email."""
+    try:
+        message = MessageSchema(
+            subject="Confirm your Telegram account — IU Alumni",
+            recipients=[email],
+            template_body={
+                "first_name": first_name,
+                "telegram_alias": telegram_alias.lstrip("@"),
+                "verify_link": verify_link,
+                "expiry_hours": expiry_hours,
+            },
+            subtype=MessageType.html,
+        )
+        logger.info("Sending Telegram verification email to %s", email)
+        await fm.send_message(message, template_name="telegram_verification.html")
+        return True
+    except Exception:
+        logger.exception("Failed to send Telegram verification email to %s", email)
+        return False

--- a/app/services/verification_service.py
+++ b/app/services/verification_service.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta
+import os
 import random
+import secrets
 import string
 
 from sqlalchemy.orm import Session
@@ -9,26 +11,27 @@ from app.models.email_verification import EmailVerification
 from app.models.users import Alumni
 
 
+VERIFICATION_LINK_EXPIRY_HOURS = int(os.getenv("VERIFICATION_LINK_EXPIRY_HOURS", "24"))
+
+
 def generate_verification_code() -> str:
     """Generate a 6-digit verification code"""
     return "".join(random.choices(string.digits, k=6))
 
 
-def create_verification_record(
-    db: Session, alumni_id: str, manual_verification: bool = False
-) -> EmailVerification:
+def create_link_verification_record(
+    db: Session, alumni_id: str
+) -> tuple[EmailVerification, str]:
     """
-    Create a new email verification record
-
-    Args:
-        db: Database session
-        alumni_id: ID of the alumni user
-        manual_verification: Whether manual verification was requested
+    Create or update a link-based email verification record.
 
     Returns:
-        EmailVerification: Created verification record
+        tuple: (EmailVerification record, raw token string)
     """
-    # Check if verification record already exists
+    token = secrets.token_urlsafe(32)
+    now = datetime.utcnow()
+    expires = now + timedelta(hours=VERIFICATION_LINK_EXPIRY_HOURS)
+
     existing = (
         db.query(EmailVerification)
         .filter(EmailVerification.alumni_id == alumni_id)
@@ -36,23 +39,91 @@ def create_verification_record(
     )
 
     if existing:
-        # Update existing record with new code
+        existing.verification_token = token
+        existing.verification_token_expires = expires
+        existing.verification_requested_at = now
+        existing.verified_at = None
+        db.commit()
+        db.refresh(existing)
+        return existing, token
+
+    record = EmailVerification(
+        id=get_random_token(),
+        alumni_id=alumni_id,
+        verification_token=token,
+        verification_token_expires=expires,
+        verification_requested_at=now,
+        manual_verification_requested=False,
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+    return record, token
+
+
+def verify_by_token(db: Session, token: str) -> tuple[bool, str, Alumni | None]:
+    """
+    Verify a user via their email verification token.
+
+    Returns:
+        tuple: (success, message, alumni_or_None)
+    """
+    record = (
+        db.query(EmailVerification)
+        .filter(EmailVerification.verification_token == token)
+        .first()
+    )
+
+    if not record:
+        return False, "Invalid or expired verification link", None
+
+    if record.verified_at is not None:
+        return False, "Account already verified", None
+
+    if record.verification_token_expires is None or datetime.utcnow() > record.verification_token_expires:
+        return False, "Verification link has expired. Please request a new one.", None
+
+    alumni = db.query(Alumni).filter(Alumni.id == record.alumni_id).first()
+    if not alumni:
+        return False, "User not found", None
+
+    alumni.is_verified = True
+    record.verified_at = datetime.utcnow()
+    record.verification_token = None  # invalidate
+    db.commit()
+
+    return True, "Email verified successfully", alumni
+
+
+def create_verification_record(
+    db: Session, alumni_id: str, manual_verification: bool = False
+) -> EmailVerification:
+    """
+    Create a new email verification record (legacy code path used for manual verification).
+    """
+    existing = (
+        db.query(EmailVerification)
+        .filter(EmailVerification.alumni_id == alumni_id)
+        .first()
+    )
+
+    now = datetime.utcnow()
+    if existing:
         existing.verification_code = generate_verification_code()
-        existing.verification_code_expires = datetime.utcnow() + timedelta(hours=1)
-        existing.verification_requested_at = datetime.utcnow()
+        existing.verification_code_expires = now + timedelta(hours=1)
+        existing.verification_requested_at = now
         existing.manual_verification_requested = manual_verification
         existing.verified_at = None
         db.commit()
         db.refresh(existing)
         return existing
 
-    # Create new verification record
     verification = EmailVerification(
         id=get_random_token(),
         alumni_id=alumni_id,
         verification_code=generate_verification_code(),
-        verification_code_expires=datetime.utcnow() + timedelta(hours=1),
-        verification_requested_at=datetime.utcnow(),
+        verification_code_expires=now + timedelta(hours=1),
+        verification_requested_at=now,
         manual_verification_requested=manual_verification,
     )
 
@@ -65,17 +136,8 @@ def create_verification_record(
 
 def verify_code(db: Session, email: str, code: str) -> tuple[bool, str]:
     """
-    Verify the provided verification code
-
-    Args:
-        db: Database session
-        email: User's email
-        code: Verification code to check
-
-    Returns:
-        tuple: (success: bool, message: str)
+    Verify the provided verification code (used by admin-verify path).
     """
-    # Get the alumni record
     alumni = db.query(Alumni).filter(Alumni.email == email).first()
     if not alumni:
         return False, "User not found"
@@ -83,7 +145,6 @@ def verify_code(db: Session, email: str, code: str) -> tuple[bool, str]:
     if alumni.is_verified:
         return False, "User already verified"
 
-    # Get verification record
     verification = (
         db.query(EmailVerification)
         .filter(EmailVerification.alumni_id == alumni.id)
@@ -93,35 +154,24 @@ def verify_code(db: Session, email: str, code: str) -> tuple[bool, str]:
     if not verification:
         return False, "No verification record found"
 
-    # Check if code matches
+    if not verification.verification_code:
+        return False, "No verification code issued for this account"
+
     if verification.verification_code != code:
         return False, "Invalid verification code"
 
-    # Check if code has expired
-    if datetime.utcnow() > verification.verification_code_expires:
+    if verification.verification_code_expires and datetime.utcnow() > verification.verification_code_expires:
         return False, "Verification code has expired"
 
-    # Mark as verified
     alumni.is_verified = True
     verification.verified_at = datetime.utcnow()
-
     db.commit()
 
     return True, "Email verified successfully"
 
 
 def admin_verify_user(db: Session, email: str) -> tuple[bool, str]:
-    """
-    Admin manual verification of a user
-
-    Args:
-        db: Database session
-        email: User's email to verify
-
-    Returns:
-        tuple: (success: bool, message: str)
-    """
-    # Get the alumni record
+    """Admin manual verification of a user."""
     alumni = db.query(Alumni).filter(Alumni.email == email).first()
     if not alumni:
         return False, "User not found"
@@ -129,36 +179,22 @@ def admin_verify_user(db: Session, email: str) -> tuple[bool, str]:
     if alumni.is_verified:
         return False, "User already verified"
 
-    # Mark as verified
     alumni.is_verified = True
 
-    # Update verification record if exists
     verification = (
         db.query(EmailVerification)
         .filter(EmailVerification.alumni_id == alumni.id)
         .first()
     )
-
     if verification:
         verification.verified_at = datetime.utcnow()
 
     db.commit()
-
     return True, "User verified successfully"
 
 
 def can_resend_verification(db: Session, email: str) -> tuple[bool, str, str | None]:
-    """
-    Check if user can request a new verification code
-
-    Args:
-        db: Database session
-        email: User's email
-
-    Returns:
-        tuple: (can_resend: bool, message: str, alumni_id: Optional[str])
-    """
-    # Get the alumni record
+    """Check if user can request a new verification link."""
     alumni = db.query(Alumni).filter(Alumni.email == email).first()
     if not alumni:
         return False, "User not found", None
@@ -166,7 +202,6 @@ def can_resend_verification(db: Session, email: str) -> tuple[bool, str, str | N
     if alumni.is_verified:
         return False, "User already verified", None
 
-    # Check if verification record exists
     verification = (
         db.query(EmailVerification)
         .filter(EmailVerification.alumni_id == alumni.id)
@@ -174,15 +209,12 @@ def can_resend_verification(db: Session, email: str) -> tuple[bool, str, str | N
     )
 
     if verification:
-        # Check rate limiting - allow resend after 60 seconds
-        time_since_last_request = (
-            datetime.utcnow() - verification.verification_requested_at
-        )
+        time_since_last_request = datetime.utcnow() - verification.verification_requested_at
         if time_since_last_request < timedelta(seconds=60):
             seconds_to_wait = 60 - time_since_last_request.total_seconds()
             return (
                 False,
-                f"Please wait {int(seconds_to_wait)} seconds before requesting a new code",
+                f"Please wait {int(seconds_to_wait)} seconds before requesting a new link",
                 None,
             )
 
@@ -190,17 +222,7 @@ def can_resend_verification(db: Session, email: str) -> tuple[bool, str, str | N
 
 
 def admin_unverify_user(db: Session, email: str) -> tuple[bool, str]:
-    """
-    Admin unverification of a user
-
-    Args:
-        db: Database session
-        email: User's email to unverify
-
-    Returns:
-        tuple: (success: bool, message: str)
-    """
-    # Get the alumni record
+    """Admin unverification of a user."""
     alumni = db.query(Alumni).filter(Alumni.email == email).first()
     if not alumni:
         return False, "User not found"
@@ -208,19 +230,16 @@ def admin_unverify_user(db: Session, email: str) -> tuple[bool, str]:
     if not alumni.is_verified:
         return False, "User is not verified"
 
-    # Mark as unverified
     alumni.is_verified = False
 
-    # Update verification record if exists
     verification = (
         db.query(EmailVerification)
         .filter(EmailVerification.alumni_id == alumni.id)
         .first()
     )
-
     if verification:
         verification.verified_at = None
 
     db.commit()
-
     return True, "User unverified successfully"
+

--- a/app/templates/email/telegram_verification.html
+++ b/app/templates/email/telegram_verification.html
@@ -1,0 +1,59 @@
+{% extends "_base.html" %}
+
+{% block content %}
+
+  <h2 style="margin:0 0 8px;font-size:22px;font-weight:700;color:#111827;">
+    Confirm Your Telegram Account
+  </h2>
+  <p style="margin:0 0 24px;font-size:14px;color:#6b7280;">
+    Link <strong>@{{ telegram_alias }}</strong> to your IU Alumni login
+  </p>
+
+  <p style="margin:0 0 8px;font-size:15px;color:#374151;line-height:1.6;">
+    Hi <strong>{{ first_name }}</strong>,
+  </p>
+  <p style="margin:0 0 28px;font-size:15px;color:#374151;line-height:1.6;">
+    Click the button below to verify that <strong>@{{ telegram_alias }}</strong> is your
+    Telegram account. Once verified, you will be able to log in to IU Alumni using
+    a Telegram code. This link expires in <strong>{{ expiry_hours }} hour{{ 's' if expiry_hours != 1 else '' }}</strong>.
+  </p>
+
+  <!-- CTA button -->
+  <table role="presentation" border="0" cellspacing="0" cellpadding="0"
+         style="margin:0 0 28px;">
+    <tr>
+      <td align="center" style="border-radius:7px;background-color:#2CA5E0;">
+        <a href="{{ verify_link }}"
+           style="display:inline-block;padding:14px 36px;font-size:16px;font-weight:700;
+                  color:#ffffff;text-decoration:none;border-radius:7px;
+                  background-color:#2CA5E0;letter-spacing:0.1px;">
+          Verify Telegram
+        </a>
+      </td>
+    </tr>
+  </table>
+
+  <!-- Fallback link -->
+  <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0"
+         style="margin:0 0 28px;background-color:#f9fafb;border:1px solid #e5e7eb;
+                border-radius:8px;">
+    <tr>
+      <td style="padding:16px 20px;">
+        <p style="margin:0 0 6px;font-size:12px;font-weight:600;color:#6b7280;
+                  letter-spacing:0.5px;text-transform:uppercase;">
+          Or copy this link into your browser
+        </p>
+        <p style="margin:0;font-size:13px;color:#2CA5E0;word-break:break-all;
+                  line-height:1.5;">
+          {{ verify_link }}
+        </p>
+      </td>
+    </tr>
+  </table>
+
+  <p style="margin:0;font-size:14px;color:#6b7280;line-height:1.6;">
+    If you didn't request Telegram verification, please ignore this email.
+    Your account settings will not change.
+  </p>
+
+{% endblock %}

--- a/app/templates/email/verification_link.html
+++ b/app/templates/email/verification_link.html
@@ -1,0 +1,58 @@
+{% extends "_base.html" %}
+
+{% block content %}
+
+  <h2 style="margin:0 0 8px;font-size:22px;font-weight:700;color:#111827;">
+    Verify Your Email
+  </h2>
+  <p style="margin:0 0 24px;font-size:14px;color:#6b7280;">
+    One click to activate your IU Alumni account
+  </p>
+
+  <p style="margin:0 0 8px;font-size:15px;color:#374151;line-height:1.6;">
+    Hi <strong>{{ first_name }}</strong>,
+  </p>
+  <p style="margin:0 0 28px;font-size:15px;color:#374151;line-height:1.6;">
+    Thanks for registering! Click the button below to confirm your email address
+    and activate your account. This link expires in
+    <strong>{{ expiry_hours }} hour{{ 's' if expiry_hours != 1 else '' }}</strong>.
+  </p>
+
+  <!-- CTA button -->
+  <table role="presentation" border="0" cellspacing="0" cellpadding="0"
+         style="margin:0 0 28px;">
+    <tr>
+      <td align="center" style="border-radius:7px;background-color:#40BA21;">
+        <a href="{{ verify_link }}"
+           style="display:inline-block;padding:14px 36px;font-size:16px;font-weight:700;
+                  color:#ffffff;text-decoration:none;border-radius:7px;
+                  background-color:#40BA21;letter-spacing:0.1px;">
+          Verify Email
+        </a>
+      </td>
+    </tr>
+  </table>
+
+  <!-- Fallback link -->
+  <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0"
+         style="margin:0 0 28px;background-color:#f9fafb;border:1px solid #e5e7eb;
+                border-radius:8px;">
+    <tr>
+      <td style="padding:16px 20px;">
+        <p style="margin:0 0 6px;font-size:12px;font-weight:600;color:#6b7280;
+                  letter-spacing:0.5px;text-transform:uppercase;">
+          Or copy this link into your browser
+        </p>
+        <p style="margin:0;font-size:13px;color:#40BA21;word-break:break-all;
+                  line-height:1.5;">
+          {{ verify_link }}
+        </p>
+      </td>
+    </tr>
+  </table>
+
+  <p style="margin:0;font-size:14px;color:#6b7280;line-height:1.6;">
+    If you didn't create an IU Alumni account, please ignore this email.
+  </p>
+
+{% endblock %}


### PR DESCRIPTION
## Summary

This PR refactors the authentication system:

1. **No Telegram fallback** — removed Telegram bot fallback from email OTP login.
2. **Link-based registration verification** — replaced 6-digit code with a clickable link (`GET /auth/verify?token=`).
3. **Telegram OTP as first-class login** — new `POST /auth/login/telegram/request` + `/verify` endpoints (requires `is_telegram_verified=True`).
4. **Profile-side Telegram verification** — `POST /auth/telegram/verify/request` sends email link; `GET /auth/telegram/verify?token=` sets `is_telegram_verified=True`. Resets when `telegram_alias` changes.

## New endpoints
- `GET /auth/verify?token=` — link-based email verification
- `POST /auth/login/telegram/request` + `/verify` — Telegram OTP login
- `POST /auth/telegram/verify/request` + `GET /auth/telegram/verify` — profile Telegram verification

## Model/DB changes
- `Alumni`: `is_telegram_verified` boolean column
- `EmailVerification`: `verification_token` columns; `verification_code` now nullable
- `TelegramVerifyToken`: new table
- Alembic migration included

## Other
- `telegram_alias` is now optional at registration
- Profile update resets `is_telegram_verified=False` when alias changes
- New email HTML templates

## Env vars needed
- `BACKEND_URL` — public base URL for verification links
- `MINI_APP_URL` — for Open App link in success pages