### PR TITLE
feat(badges): badge system backend

### DIFF
--- a/alembic/versions/c1d2e3f4a5b6_add_badges.py
+++ b/alembic/versions/c1d2e3f4a5b6_add_badges.py
@@ -1,0 +1,254 @@
+"""add badges
+
+Revision ID: c1d2e3f4a5b6
+Revises: a3b4c5d6e7f8
+Create Date: 2026-06-17
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "c1d2e3f4a5b6"
+down_revision: Union[str, None] = "a3b4c5d6e7f8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _badges_table() -> sa.Table:
+    return sa.table(
+        "badges",
+        sa.column("id", sa.String),
+        sa.column("code", sa.String),
+        sa.column("name", sa.String),
+        sa.column("description", sa.String),
+        sa.column("tier", sa.String),
+        sa.column("icon_key", sa.String),
+        sa.column("strategy", sa.String),
+        sa.column("params", postgresql.JSONB),
+        sa.column("trigger_metrics", postgresql.ARRAY(sa.String)),
+    )
+
+
+_SEED = [
+    dict(
+        id="bdg-pioneer",
+        code="pioneer",
+        name="Pioneer",
+        description="Among the first 100 alumni to pin their location on the map.",
+        tier="special",
+        icon_key="flag",
+        strategy="first_n",
+        params={"n": 100},
+        trigger_metrics=["profile_updated"],
+    ),
+    dict(
+        id="bdg-local-legend",
+        code="local_legend",
+        name="Local Legend",
+        description="Most events attended in a single city in a given year.",
+        tier="gold",
+        icon_key="crown",
+        strategy="leaderboard",
+        params={},
+        trigger_metrics=[],
+    ),
+    dict(
+        id="bdg-founding-host",
+        code="founding_host",
+        name="Founding Host",
+        description="Created the first alumni event in a city.",
+        tier="gold",
+        icon_key="flag",
+        strategy="per_city_first",
+        params={},
+        trigger_metrics=["event_approved"],
+    ),
+    dict(
+        id="bdg-networker",
+        code="networker",
+        name="Networker",
+        description="Attended 5+ alumni events.",
+        tier="bronze",
+        icon_key="people",
+        strategy="count_threshold",
+        params={"metric": "events_attended", "threshold": 5},
+        trigger_metrics=["event_attended"],
+    ),
+    dict(
+        id="bdg-host-most",
+        code="host_with_the_most",
+        name="Host with the most",
+        description="Organized 3+ events in different cities.",
+        tier="silver",
+        icon_key="trophy",
+        strategy="distinct_count",
+        params={"metric": "distinct_cities_hosted", "threshold": 3},
+        trigger_metrics=["event_approved"],
+    ),
+    dict(
+        id="bdg-rainmaker",
+        code="rainmaker",
+        name="Rainmaker",
+        description="An event you created had 20+ attendees.",
+        tier="silver",
+        icon_key="spark",
+        strategy="count_threshold",
+        params={"metric": "max_attendees_on_owned", "threshold": 20},
+        trigger_metrics=["event_attended", "event_approved"],
+    ),
+    dict(
+        id="bdg-cross-city",
+        code="cross_city_commuter",
+        name="Cross-city commuter",
+        description="Attended an event in a city different from your home city.",
+        tier="bronze",
+        icon_key="travel",
+        strategy="count_threshold",
+        params={"metric": "cross_city_attendances", "threshold": 1},
+        trigger_metrics=["event_attended"],
+    ),
+    dict(
+        id="bdg-innopolis-og",
+        code="innopolis_og",
+        name="Innopolis OG",
+        description="Graduated from one of the first cohorts (2014-2019).",
+        tier="gold",
+        icon_key="graduation",
+        strategy="year_range",
+        params={"field": "graduation_year", "min": 2014, "max": 2019},
+        trigger_metrics=["profile_updated"],
+    ),
+    dict(
+        id="bdg-profile-pro",
+        code="profile_pro",
+        name="Profile Pro",
+        description="Completed all profile fields: photo, location, biography, graduation year, Telegram.",
+        tier="bronze",
+        icon_key="profile_check",
+        strategy="profile_completeness",
+        params={
+            "fields": [
+                "avatar",
+                "location",
+                "biography",
+                "graduation_year",
+                "telegram_alias",
+            ]
+        },
+        trigger_metrics=["profile_updated"],
+    ),
+    dict(
+        id="bdg-badge-collector",
+        code="badge_collector",
+        name="Badge Collector",
+        description="Earned 10+ badges.",
+        tier="gold",
+        icon_key="collection",
+        strategy="badge_count",
+        params={"threshold": 10},
+        trigger_metrics=["badge_awarded"],
+    ),
+    dict(
+        id="bdg-open-source",
+        code="open_source_contributor",
+        name="Open Source Contributor",
+        description="Contributed to the platform's open-source codebase.",
+        tier="silver",
+        icon_key="code",
+        strategy="manual",
+        params={},
+        trigger_metrics=[],
+    ),
+    dict(
+        id="bdg-suggestion",
+        code="suggestion_box",
+        name="Suggestion Box",
+        description="Submitted a badge or feature idea that got implemented.",
+        tier="special",
+        icon_key="lightbulb",
+        strategy="manual",
+        params={},
+        trigger_metrics=[],
+    ),
+]
+
+
+def upgrade() -> None:
+    op.create_table(
+        "badges",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("code", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=False),
+        sa.Column("tier", sa.String(), nullable=False),
+        sa.Column("icon_key", sa.String(), nullable=False),
+        sa.Column("strategy", sa.String(), nullable=False),
+        sa.Column(
+            "params",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="{}",
+        ),
+        sa.Column(
+            "trigger_metrics",
+            postgresql.ARRAY(sa.String()),
+            nullable=False,
+            server_default="{}",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.UniqueConstraint("code", name="uq_badges_code"),
+    )
+
+    op.create_table(
+        "user_badges",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column(
+            "alumni_id",
+            sa.String(),
+            sa.ForeignKey("alumni.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "badge_id",
+            sa.String(),
+            sa.ForeignKey("badges.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "awarded_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("seen_at", sa.DateTime(), nullable=True),
+        sa.Column(
+            "extra",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="{}",
+        ),
+        sa.Column("awarded_by", sa.String(), nullable=True),
+        sa.UniqueConstraint(
+            "alumni_id", "badge_id", "extra", name="uq_user_badges_unique"
+        ),
+    )
+    op.create_index(
+        "ix_user_badges_alumni", "user_badges", ["alumni_id"], unique=False
+    )
+
+    op.bulk_insert(_badges_table(), _SEED)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_badges_alumni", table_name="user_badges")
+    op.drop_table("user_badges")
+    op.drop_table("badges")

--- a/app/api/routes/admin/approve_event.py
+++ b/app/api/routes/admin/approve_event.py
@@ -34,4 +34,20 @@ async def approve_event(
     event.approved = True
     db.commit()
     db.refresh(event)
+
+    # Badge eval for the host (Founding Host, Host with the most, Rainmaker).
+    try:
+        from app.services.badges import award_founding_host, evaluate_for_user
+
+        owner = db.query(Alumni).filter(Alumni.id == event.owner_id).first()
+        if owner is not None:
+            evaluate_for_user(db, owner, "event_approved")
+            if award_founding_host(db, owner, event) is not None:
+                db.commit()
+    except Exception as eval_err:  # noqa: BLE001
+        import logging
+        logging.getLogger("iu_alumni").error(
+            "badge eval failed on event_approved: %s", eval_err
+        )
+
     return event

--- a/app/api/routes/admin/approve_event.py
+++ b/app/api/routes/admin/approve_event.py
@@ -44,7 +44,7 @@ async def approve_event(
             evaluate_for_user(db, owner, "event_approved")
             if award_founding_host(db, owner, event) is not None:
                 db.commit()
-    except Exception as eval_err:  # noqa: BLE001
+    except Exception as eval_err:
         import logging
         logging.getLogger("iu_alumni").error(
             "badge eval failed on event_approved: %s", eval_err

--- a/app/api/routes/badges/__init__.py
+++ b/app/api/routes/badges/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from . import catalog, my_badges, other_badges, mark_seen
+from . import catalog, mark_seen, my_badges, other_badges
 
 
 router = APIRouter()

--- a/app/api/routes/badges/__init__.py
+++ b/app/api/routes/badges/__init__.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from . import catalog, my_badges, other_badges, mark_seen
+
+
+router = APIRouter()
+router.include_router(catalog.router)
+router.include_router(my_badges.router)
+router.include_router(other_badges.router)
+router.include_router(mark_seen.router)

--- a/app/api/routes/badges/catalog.py
+++ b/app/api/routes/badges/catalog.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.models.badge import Badge
+from app.schemas.badge import BadgeBase
+
+
+router = APIRouter()
+
+
+@router.get("/", response_model=list[BadgeBase])
+def get_catalog(db: Session = Depends(get_db)):
+    """Public catalog of all badges. No per-user state."""
+    return [
+        BadgeBase(
+            code=b.code,
+            name=b.name,
+            description=b.description,
+            tier=b.tier,
+            icon_key=b.icon_key,
+        )
+        for b in db.query(Badge).all()
+    ]

--- a/app/api/routes/badges/mark_seen.py
+++ b/app/api/routes/badges/mark_seen.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import get_current_user
+from app.models.users import Alumni
+from app.schemas.badge import MarkSeenResponse
+from app.services.badges import mark_seen
+
+
+router = APIRouter()
+
+
+@router.post("/me/{badge_code}/seen", response_model=MarkSeenResponse)
+def mark_badge_seen(
+    badge_code: str,
+    current_user: Alumni = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Mark a newly-earned badge as seen so the popup doesn't reappear."""
+    if not isinstance(current_user, Alumni):
+        raise HTTPException(
+            status_code=403, detail="Your account is not an alumni account"
+        )
+    return MarkSeenResponse(success=mark_seen(db, current_user, badge_code))

--- a/app/api/routes/badges/my_badges.py
+++ b/app/api/routes/badges/my_badges.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import get_current_user
+from app.models.users import Alumni
+from app.schemas.badge import MyBadgesResponse
+from app.services.badges import evaluate_for_user, list_my_badges
+
+
+router = APIRouter()
+
+
+@router.get("/me", response_model=MyBadgesResponse)
+def get_my_badges(
+    current_user: Alumni = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Current user's earned + locked badges, with progress on locked ones."""
+    if not isinstance(current_user, Alumni):
+        raise HTTPException(
+            status_code=403, detail="Your account is not an alumni account"
+        )
+    # Re-evaluate every trigger on read so the user always sees current
+    # state, even if a trigger hook missed for any reason. Cheap — bounded
+    # by catalog size and the per-trigger lookup is indexed.
+    for trigger in (
+        "profile_updated",
+        "event_attended",
+        "event_approved",
+        "badge_awarded",
+    ):
+        evaluate_for_user(db, current_user, trigger)
+    return list_my_badges(db, current_user)

--- a/app/api/routes/badges/other_badges.py
+++ b/app/api/routes/badges/other_badges.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.schemas.badge import UserBadgesResponse
+from app.services.badges import list_for_user
+
+
+router = APIRouter()
+
+
+@router.get("/users/{alumni_id}", response_model=UserBadgesResponse)
+def get_user_badges(alumni_id: str, db: Session = Depends(get_db)):
+    """Public view of someone else's earned badges. No auth required."""
+    data = list_for_user(db, alumni_id)
+    return UserBadgesResponse(earned=data["earned"])

--- a/app/api/routes/events/event_add_participant.py
+++ b/app/api/routes/events/event_add_participant.py
@@ -78,7 +78,7 @@ async def add_participant(
         # Badge evaluation (failure-tolerant — never blocks the response).
         try:
             evaluate_for_user(db, participant, "event_attended")
-        except Exception as eval_err:  # noqa: BLE001
+        except Exception as eval_err:
             import logging
             logging.getLogger("iu_alumni").error(
                 "badge eval failed on event_attended: %s", eval_err

--- a/app/api/routes/events/event_add_participant.py
+++ b/app/api/routes/events/event_add_participant.py
@@ -5,6 +5,7 @@ from app.core.database import get_db
 from app.core.security import get_current_user
 from app.models.events import Event
 from app.models.users import Admin, Alumni
+from app.services.badges import evaluate_for_user
 from app.services.notification_service import NotificationService
 
 
@@ -72,6 +73,15 @@ async def add_participant(
                 event_name=event.title,
                 owner_alias=owner.telegram_alias,
                 user_alias=participant.telegram_alias,
+            )
+
+        # Badge evaluation (failure-tolerant — never blocks the response).
+        try:
+            evaluate_for_user(db, participant, "event_attended")
+        except Exception as eval_err:  # noqa: BLE001
+            import logging
+            logging.getLogger("iu_alumni").error(
+                "badge eval failed on event_attended: %s", eval_err
             )
 
         return {"message": "Successfully joined the event"}

--- a/app/api/routes/profile/profile.py
+++ b/app/api/routes/profile/profile.py
@@ -68,4 +68,14 @@ def update_profile(
     db.commit()
     db.refresh(current_user)
 
+    # Badge eval (Pioneer, Innopolis OG, Profile Pro, Cross-city commuter).
+    try:
+        from app.services.badges import evaluate_for_user
+        evaluate_for_user(db, current_user, "profile_updated")
+    except Exception as eval_err:  # noqa: BLE001
+        import logging
+        logging.getLogger("iu_alumni").error(
+            "badge eval failed on profile_updated: %s", eval_err
+        )
+
     return current_user

--- a/app/api/routes/profile/profile.py
+++ b/app/api/routes/profile/profile.py
@@ -72,7 +72,7 @@ def update_profile(
     try:
         from app.services.badges import evaluate_for_user
         evaluate_for_user(db, current_user, "profile_updated")
-    except Exception as eval_err:  # noqa: BLE001
+    except Exception as eval_err:
         import logging
         logging.getLogger("iu_alumni").error(
             "badge eval failed on profile_updated: %s", eval_err

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.api.routes.admin import router as admin_router
 from app.api.routes.authentication import router as auth_router
+from app.api.routes.badges import router as badges_router
 from app.api.routes.cities import router as cities_router
 from app.api.routes.events import router as events_router
 from app.api.routes.profile import router as profile_router
@@ -115,6 +116,7 @@ api_v1.include_router(profile_router, prefix="/profile", tags=["Profile"])
 api_v1.include_router(events_router, prefix="/events", tags=["Events"])
 api_v1.include_router(admin_router, prefix="/admin", tags=["Admin"])
 api_v1.include_router(cities_router, prefix="/cities", tags=["Cities"])
+api_v1.include_router(badges_router, prefix="/badges", tags=["Badges"])
 app.include_router(api_v1)
 app.include_router(telegram_router, tags=["Telegram"])
 

--- a/app/models/badge.py
+++ b/app/models/badge.py
@@ -1,0 +1,44 @@
+from sqlalchemy import Column, DateTime, ForeignKey, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+
+
+class Badge(Base):
+    __tablename__ = "badges"
+
+    id = Column(String, primary_key=True)
+    code = Column(String, unique=True, nullable=False, index=True)
+    name = Column(String, nullable=False)
+    description = Column(String, nullable=False)
+    tier = Column(String, nullable=False)  # gold|silver|bronze|special
+    icon_key = Column(String, nullable=False)
+    strategy = Column(String, nullable=False)
+    params = Column(JSONB, nullable=False, default=dict)
+    trigger_metrics = Column(ARRAY(String), nullable=False, default=list)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+    awards = relationship("UserBadge", back_populates="badge")
+
+
+class UserBadge(Base):
+    __tablename__ = "user_badges"
+    __table_args__ = (
+        UniqueConstraint(
+            "alumni_id", "badge_id", "extra", name="uq_user_badges_unique"
+        ),
+    )
+
+    id = Column(String, primary_key=True)
+    alumni_id = Column(
+        String, ForeignKey("alumni.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    badge_id = Column(String, ForeignKey("badges.id", ondelete="CASCADE"), nullable=False)
+    awarded_at = Column(DateTime, nullable=False, server_default=func.now())
+    seen_at = Column(DateTime, nullable=True)
+    extra = Column(JSONB, nullable=False, default=dict)  # e.g. {"city": "...", "year": ...}
+    awarded_by = Column(String, nullable=True)
+
+    badge = relationship("Badge", back_populates="awards")

--- a/app/schemas/badge.py
+++ b/app/schemas/badge.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class BadgeBase(BaseModel):
+    code: str
+    name: str
+    description: str
+    tier: str
+    icon_key: str
+
+
+class EarnedBadge(BadgeBase):
+    awarded_at: datetime
+    extra: dict[str, Any] = {}
+
+
+class LockedBadge(BadgeBase):
+    progress: int
+    threshold: int
+    metric_label: str
+
+
+class MyBadgesResponse(BaseModel):
+    earned: list[EarnedBadge]
+    locked: list[LockedBadge]
+    newly_earned: list[BadgeBase]
+
+
+class UserBadgesResponse(BaseModel):
+    earned: list[EarnedBadge]
+
+
+class MarkSeenResponse(BaseModel):
+    success: bool

--- a/app/services/badges.py
+++ b/app/services/badges.py
@@ -1,0 +1,450 @@
+"""Badge evaluation engine.
+
+Given an alumni and a trigger metric, looks up every badge whose
+trigger_metrics include the trigger, dispatches to the right strategy
+implementation, and awards anything that just crossed the threshold.
+
+Public entry points:
+    evaluate_for_user(db, alumni, trigger) -> list[UserBadge]
+    list_my_badges(db, alumni) -> dict   # for /profile/me/badges
+    list_for_user(db, alumni_id) -> dict # public view
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Iterable
+
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.badge import Badge, UserBadge
+from app.models.events import Event
+from app.models.users import Alumni
+
+logger = logging.getLogger("iu_alumni")
+
+
+# ─────────────────────────── progress helpers ──────────────────────────────
+
+
+def _events_attended_count(db: Session, alumni_id: str) -> int:
+    return (
+        db.query(func.count(Event.id))
+        .filter(Event.participants_ids.any(alumni_id))
+        .scalar()
+        or 0
+    )
+
+
+def _owned_events(db: Session, alumni_id: str) -> list[Event]:
+    return db.query(Event).filter(Event.owner_id == alumni_id).all()
+
+
+def _distinct_cities_hosted(db: Session, alumni_id: str) -> int:
+    rows = (
+        db.query(func.lower(func.trim(Event.location)))
+        .filter(Event.owner_id == alumni_id, Event.approved.is_(True))
+        .distinct()
+        .all()
+    )
+    return len({r[0] for r in rows if r[0]})
+
+
+def _max_attendees_on_owned(db: Session, alumni_id: str) -> int:
+    owned = _owned_events(db, alumni_id)
+    return max((len(e.participants_ids or []) for e in owned), default=0)
+
+
+def _cross_city_attendances(db: Session, alumni: Alumni) -> int:
+    if not alumni.location:
+        return 0
+    home = alumni.location.strip().lower()
+    rows = (
+        db.query(Event.location)
+        .filter(Event.participants_ids.any(alumni.id))
+        .all()
+    )
+    return sum(
+        1 for (loc,) in rows if loc and loc.strip().lower() != home
+    )
+
+
+def _profile_fields_complete(alumni: Alumni, fields: list[str]) -> tuple[int, int]:
+    """Returns (filled, total) — number of listed fields that are non-empty."""
+    filled = 0
+    for f in fields:
+        v = getattr(alumni, f, None)
+        if v not in (None, ""):
+            filled += 1
+    return filled, len(fields)
+
+
+def _badge_count(db: Session, alumni_id: str) -> int:
+    return (
+        db.query(func.count(UserBadge.id))
+        .filter(UserBadge.alumni_id == alumni_id)
+        .scalar()
+        or 0
+    )
+
+
+# ─────────────────────────── strategies ────────────────────────────────────
+
+
+def _strategy_progress(
+    db: Session, alumni: Alumni, badge: Badge
+) -> tuple[int, int, str]:
+    """Returns (progress, threshold, metric_label) for the locked card UI."""
+    params = badge.params or {}
+    strat = badge.strategy
+
+    if strat == "count_threshold":
+        metric = params.get("metric", "")
+        threshold = int(params.get("threshold", 1))
+        if metric == "events_attended":
+            return (
+                _events_attended_count(db, alumni.id),
+                threshold,
+                "alumni events attended",
+            )
+        if metric == "max_attendees_on_owned":
+            return (
+                _max_attendees_on_owned(db, alumni.id),
+                threshold,
+                "attendees on biggest hosted event",
+            )
+        if metric == "cross_city_attendances":
+            return (
+                _cross_city_attendances(db, alumni),
+                threshold,
+                "events attended outside home city",
+            )
+
+    if strat == "distinct_count":
+        threshold = int(params.get("threshold", 1))
+        if params.get("metric") == "distinct_cities_hosted":
+            return (
+                _distinct_cities_hosted(db, alumni.id),
+                threshold,
+                "distinct cities hosted in",
+            )
+
+    if strat == "year_range":
+        try:
+            year = int(alumni.graduation_year)
+        except (TypeError, ValueError):
+            year = 0
+        lo, hi = int(params.get("min", 0)), int(params.get("max", 0))
+        in_range = 1 if lo <= year <= hi else 0
+        return in_range, 1, f"graduation year in {lo}-{hi}"
+
+    if strat == "profile_completeness":
+        fields = params.get("fields", [])
+        filled, total = _profile_fields_complete(alumni, fields)
+        return filled, total, "profile fields completed"
+
+    if strat == "badge_count":
+        threshold = int(params.get("threshold", 10))
+        return _badge_count(db, alumni.id), threshold, "badges earned"
+
+    if strat == "first_n":
+        n = int(params.get("n", 1))
+        awarded_so_far = (
+            db.query(func.count(UserBadge.id))
+            .filter(UserBadge.badge_id == badge.id)
+            .scalar()
+            or 0
+        )
+        # "Progress" here means how close the user is to qualifying — for
+        # Pioneer that's just "has show_location been flipped." Once flipped,
+        # they qualify if there's still room (awarded_so_far < n).
+        qualifies = 1 if getattr(alumni, "show_location", False) and alumni.location else 0
+        if awarded_so_far >= n:
+            # Window closed.
+            return 0, 1, f"first {n} to pin location (window closed)"
+        return qualifies, 1, f"first {n} to pin location on map"
+
+    if strat == "per_city_first":
+        # Always shows as not-yet — we can't pre-judge a city.
+        return 0, 1, "create the first event in a new city"
+
+    if strat in ("leaderboard", "manual"):
+        return 0, 1, "awarded by an admin" if strat == "manual" else "year-end leaderboard"
+
+    return 0, 1, "criteria"
+
+
+def _should_award(
+    db: Session, alumni: Alumni, badge: Badge
+) -> tuple[bool, dict[str, Any]]:
+    """Returns (should_award, extra_metadata). Pure read of current state."""
+    params = badge.params or {}
+    strat = badge.strategy
+
+    if strat == "count_threshold":
+        progress, threshold, _ = _strategy_progress(db, alumni, badge)
+        return progress >= threshold, {}
+
+    if strat == "distinct_count":
+        progress, threshold, _ = _strategy_progress(db, alumni, badge)
+        return progress >= threshold, {}
+
+    if strat == "year_range":
+        try:
+            year = int(alumni.graduation_year)
+        except (TypeError, ValueError):
+            return False, {}
+        lo, hi = int(params.get("min", 0)), int(params.get("max", 0))
+        return lo <= year <= hi, {}
+
+    if strat == "profile_completeness":
+        fields = params.get("fields", [])
+        filled, total = _profile_fields_complete(alumni, fields)
+        return filled >= total and total > 0, {}
+
+    if strat == "badge_count":
+        threshold = int(params.get("threshold", 10))
+        return _badge_count(db, alumni.id) >= threshold, {}
+
+    if strat == "first_n":
+        n = int(params.get("n", 1))
+        if not (getattr(alumni, "show_location", False) and alumni.location):
+            return False, {}
+        # Atomic gate: count under lock when we actually insert.
+        awarded_so_far = (
+            db.query(func.count(UserBadge.id))
+            .filter(UserBadge.badge_id == badge.id)
+            .scalar()
+            or 0
+        )
+        return awarded_so_far < n, {}
+
+    if strat == "per_city_first":
+        # Awarded by the event_approved hook with city metadata. We need a
+        # city to make the decision; without an event in scope we can't.
+        return False, {}
+
+    # leaderboard + manual never auto-award.
+    return False, {}
+
+
+def _award(
+    db: Session, alumni_id: str, badge: Badge, extra: dict | None = None
+) -> UserBadge | None:
+    """Insert a UserBadge row. Idempotent on (alumni_id, badge_id, extra)."""
+    row = UserBadge(
+        id=str(uuid.uuid4()),
+        alumni_id=alumni_id,
+        badge_id=badge.id,
+        awarded_at=datetime.utcnow(),
+        extra=extra or {},
+    )
+    db.add(row)
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        return None
+    return row
+
+
+# ─────────────────────────── public API ────────────────────────────────────
+
+
+def evaluate_for_user(
+    db: Session, alumni: Alumni, trigger: str, context: dict | None = None
+) -> list[UserBadge]:
+    """Evaluate every badge whose trigger_metrics include `trigger`.
+
+    Failure-tolerant: each badge's eval is wrapped so one bad strategy
+    doesn't block the others or the calling request.
+
+    Recursion guard: if `trigger == "badge_awarded"` (set by us after every
+    award to chain Badge Collector), we skip awarding Badge Collector itself
+    from inside a Badge Collector awarding to avoid an infinite loop.
+    """
+    if context is None:
+        context = {}
+
+    badges = (
+        db.query(Badge).filter(Badge.trigger_metrics.contains([trigger])).all()
+    )
+    already = {
+        ub.badge_id
+        for ub in db.query(UserBadge.badge_id)
+        .filter(UserBadge.alumni_id == alumni.id)
+        .all()
+    }
+
+    newly_awarded: list[UserBadge] = []
+    for b in badges:
+        # Skip already-earned single-instance badges. Per-city/leaderboard
+        # badges live in `extra` so we allow repeats — but for v1 the only
+        # badge that can repeat is Local Legend (manual-cron), so this
+        # blanket-skip is fine.
+        if b.id in already and b.strategy not in ("per_city_first",):
+            continue
+        # Anti-recursion: don't re-evaluate Badge Collector inside its own chain.
+        if b.code == "badge_collector" and context.get("from_badge_awarded"):
+            continue
+        try:
+            should, extra = _should_award(db, alumni, b)
+            if should:
+                row = _award(db, alumni.id, b, extra)
+                if row is not None:
+                    newly_awarded.append(row)
+        except Exception as e:
+            logger.error("badge eval failed for %s: %s", b.code, e)
+
+    if newly_awarded:
+        db.commit()
+        # Chain into Badge Collector evaluation.
+        try:
+            chained = evaluate_for_user(
+                db,
+                alumni,
+                "badge_awarded",
+                context={"from_badge_awarded": True},
+            )
+            newly_awarded.extend(chained)
+        except Exception as e:
+            logger.error("badge_awarded cascade failed: %s", e)
+
+    return newly_awarded
+
+
+def award_founding_host(
+    db: Session, alumni: Alumni, event: Event
+) -> UserBadge | None:
+    """Per-city first hook — call when an event is approved.
+
+    Awards "Founding Host" with metadata={"city": <event.location lowercased>}
+    if no earlier approved event exists in that city.
+    """
+    if not event.location:
+        return None
+    badge = db.query(Badge).filter(Badge.code == "founding_host").first()
+    if not badge:
+        return None
+    city = event.location.strip().lower()
+
+    # Is there an earlier approved event in this city by anyone (incl. self)?
+    earlier = (
+        db.query(Event)
+        .filter(
+            Event.approved.is_(True),
+            func.lower(func.trim(Event.location)) == city,
+            Event.datetime < event.datetime,
+        )
+        .first()
+    )
+    if earlier is not None:
+        return None
+
+    return _award(db, alumni.id, badge, {"city": city})
+
+
+def list_my_badges(db: Session, alumni: Alumni) -> dict[str, Any]:
+    """Shape: {earned: [...], locked: [...], newly_earned: [...]}.
+
+    Computes progress on locked badges from current data; no progress table.
+    """
+    catalog = db.query(Badge).all()
+    awards = (
+        db.query(UserBadge).filter(UserBadge.alumni_id == alumni.id).all()
+    )
+    earned_index: dict[str, list[UserBadge]] = {}
+    for a in awards:
+        earned_index.setdefault(a.badge_id, []).append(a)
+
+    earned: list[dict] = []
+    locked: list[dict] = []
+    newly: list[dict] = []
+    seen_to_mark: list[UserBadge] = []
+
+    for b in catalog:
+        if b.id in earned_index:
+            for ub in earned_index[b.id]:
+                earned.append(
+                    {
+                        "code": b.code,
+                        "name": b.name,
+                        "description": b.description,
+                        "tier": b.tier,
+                        "icon_key": b.icon_key,
+                        "awarded_at": ub.awarded_at,
+                        "extra": ub.extra or {},
+                    }
+                )
+                if ub.seen_at is None:
+                    newly.append(
+                        {
+                            "code": b.code,
+                            "name": b.name,
+                            "description": b.description,
+                            "tier": b.tier,
+                            "icon_key": b.icon_key,
+                        }
+                    )
+                    seen_to_mark.append(ub)
+        else:
+            progress, threshold, metric = _strategy_progress(db, alumni, b)
+            locked.append(
+                {
+                    "code": b.code,
+                    "name": b.name,
+                    "description": b.description,
+                    "tier": b.tier,
+                    "icon_key": b.icon_key,
+                    "progress": progress,
+                    "threshold": threshold,
+                    "metric_label": metric,
+                }
+            )
+
+    return {"earned": earned, "locked": locked, "newly_earned": newly}
+
+
+def list_for_user(db: Session, alumni_id: str) -> dict[str, Any]:
+    """Public view — earned only, no progress on locked, no newly_earned."""
+    awards = (
+        db.query(UserBadge, Badge)
+        .join(Badge, Badge.id == UserBadge.badge_id)
+        .filter(UserBadge.alumni_id == alumni_id)
+        .all()
+    )
+    earned = [
+        {
+            "code": b.code,
+            "name": b.name,
+            "description": b.description,
+            "tier": b.tier,
+            "icon_key": b.icon_key,
+            "awarded_at": ub.awarded_at,
+            "extra": ub.extra or {},
+        }
+        for ub, b in awards
+    ]
+    return {"earned": earned, "locked": [], "newly_earned": []}
+
+
+def mark_seen(db: Session, alumni: Alumni, badge_code: str) -> bool:
+    badge = db.query(Badge).filter(Badge.code == badge_code).first()
+    if not badge:
+        return False
+    rows = (
+        db.query(UserBadge)
+        .filter(
+            UserBadge.alumni_id == alumni.id,
+            UserBadge.badge_id == badge.id,
+            UserBadge.seen_at.is_(None),
+        )
+        .all()
+    )
+    for r in rows:
+        r.seen_at = datetime.utcnow()
+    db.commit()
+    return bool(rows)

--- a/app/services/badges.py
+++ b/app/services/badges.py
@@ -11,10 +11,10 @@ Public entry points:
 """
 from __future__ import annotations
 
-import logging
-import uuid
 from datetime import datetime
-from typing import Any, Iterable
+import logging
+from typing import Any
+import uuid
 
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
@@ -23,6 +23,7 @@ from sqlalchemy.orm import Session
 from app.models.badge import Badge, UserBadge
 from app.models.events import Event
 from app.models.users import Alumni
+
 
 logger = logging.getLogger("iu_alumni")
 

--- a/scripts/seed_badge_demo.py
+++ b/scripts/seed_badge_demo.py
@@ -1,0 +1,166 @@
+"""Seed enough activity so the existing user earns several more badges.
+
+Idempotent: safe to re-run. Skips anything already in place.
+
+Triggers covered:
+    - Networker: user attends 5+ events
+    - Cross-city commuter: user attends an event outside Innopolis
+    - Founding Host: user creates the first approved event in 3 new cities
+    - Host with the most: 3 distinct cities hosted -> earned
+    - Rainmaker: user hosts an event with 20+ attendees
+    - Badge Collector: chains in if total earned crosses 10
+
+Run with:
+    docker exec iu_alumni_backend python -m scripts.seed_badge_demo
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta
+
+from app.core.database import SessionLocal
+from app.models.email_verification import EmailVerification  # noqa: F401 — registers relationship
+from app.models.events import Event
+from app.models.users import Alumni
+
+USER_EMAIL = "r.mohammed@innopolis.university"
+
+
+def _ensure_alumni(db, idx: int) -> Alumni:
+    email = f"demo-attendee-{idx}@iu-alumni.local"
+    existing = db.query(Alumni).filter(Alumni.email == email).first()
+    if existing is not None:
+        return existing
+    alumni = Alumni(
+        id=f"demo-attendee-{idx}",
+        email=email,
+        hashed_password="$2b$12$placeholder.no.login.allowed.demo.account.hash",
+        first_name=f"Demo{idx}",
+        last_name="Attendee",
+        graduation_year="2020",
+        location="Innopolis",
+        is_verified=True,
+        is_banned=False,
+    )
+    db.add(alumni)
+    db.flush()
+    return alumni
+
+
+def _ensure_event(
+    db,
+    code: str,
+    owner_id: str,
+    title: str,
+    location: str,
+    days_ago: int,
+    participants_ids: list[str],
+    approved: bool = True,
+) -> Event:
+    existing = db.query(Event).filter(Event.id == code).first()
+    if existing is not None:
+        # Update key fields so re-runs reflect changes.
+        existing.participants_ids = participants_ids
+        existing.approved = approved
+        return existing
+    event = Event(
+        id=code,
+        owner_id=owner_id,
+        title=title,
+        description=f"Demo event for badge testing — {title}",
+        location=location,
+        datetime=datetime.utcnow() - timedelta(days=days_ago),
+        cost=0.0,
+        is_online=False,
+        cover=None,
+        approved=approved,
+        participants_ids=participants_ids,
+    )
+    db.add(event)
+    db.flush()
+    return event
+
+
+def main() -> None:
+    db = SessionLocal()
+    try:
+        user = db.query(Alumni).filter(Alumni.email == USER_EMAIL).first()
+        if user is None:
+            raise SystemExit(f"User {USER_EMAIL} not found")
+        print(f"seeding for user {user.id}")
+
+        # Ensure 22 attendee alumni so Rainmaker can pull 20 of them + extras.
+        attendees = [_ensure_alumni(db, i) for i in range(22)]
+        attendee_ids = [a.id for a in attendees]
+
+        # 5 events the user attends in different cities (Networker + Cross-city commuter).
+        attended_cities = [
+            ("demo-evt-1", "Innopolis Tech Meetup", "Innopolis", 60),
+            ("demo-evt-2", "Dubai Networking Night", "Dubai", 45),
+            ("demo-evt-3", "Moscow Reunion", "Moscow", 30),
+            ("demo-evt-4", "Berlin Alumni Coffee", "Berlin", 20),
+            ("demo-evt-5", "Kazan Hackathon", "Kazan", 10),
+        ]
+        for code, title, city, days_ago in attended_cities:
+            _ensure_event(
+                db,
+                code=code,
+                owner_id=attendees[0].id,
+                title=title,
+                location=city,
+                days_ago=days_ago,
+                participants_ids=[user.id, attendees[1].id, attendees[2].id],
+                approved=True,
+            )
+
+        # 3 events the USER hosts in different cities (Founding Host x3, Host with the most).
+        hosted_cities = [
+            ("demo-host-1", "User's Tashkent Talk", "Tashkent", 50),
+            ("demo-host-2", "User's Almaty Drinks", "Almaty", 35),
+            ("demo-host-3", "User's Yerevan Yoga", "Yerevan", 15),
+        ]
+        for code, title, city, days_ago in hosted_cities:
+            _ensure_event(
+                db,
+                code=code,
+                owner_id=user.id,
+                title=title,
+                location=city,
+                days_ago=days_ago,
+                participants_ids=[attendees[3].id, attendees[4].id],
+                approved=True,
+            )
+
+        # 1 huge user-hosted event for Rainmaker (>=20 attendees).
+        _ensure_event(
+            db,
+            code="demo-host-big",
+            owner_id=user.id,
+            title="User's Big Conference",
+            location="Tashkent",  # reuses Tashkent — doesn't matter for Rainmaker
+            days_ago=5,
+            participants_ids=attendee_ids[:20],  # 20 attendees
+            approved=True,
+        )
+
+        db.commit()
+
+        # Trigger Founding Host for every event the user hosts that's the
+        # earliest in its city — bypasses the approve_event hook since the
+        # seed sets approved=True directly via SQL.
+        from app.services.badges import award_founding_host
+
+        user_events = (
+            db.query(Event).filter(Event.owner_id == user.id, Event.approved.is_(True)).all()
+        )
+        for ev in user_events:
+            award_founding_host(db, user, ev)
+        db.commit()
+
+        print("done. open the mobile app, refresh profile, watch badges unlock.")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed_badge_demo.py
+++ b/scripts/seed_badge_demo.py
@@ -15,13 +15,15 @@ Run with:
 """
 from __future__ import annotations
 
-import uuid
 from datetime import datetime, timedelta
 
 from app.core.database import SessionLocal
-from app.models.email_verification import EmailVerification  # noqa: F401 — registers relationship
+from app.models.email_verification import (
+    EmailVerification,  # noqa: F401 — registers relationship
+)
 from app.models.events import Event
 from app.models.users import Alumni
+
 
 USER_EMAIL = "r.mohammed@innopolis.university"
 


### PR DESCRIPTION
## Summary

End-to-end badge system backend implementing tickets **#1, #2, #3, #5, #7, #8** from the [org project board](https://github.com/orgs/iu-alumni/projects/3). The mobile app PR ([iu-alumni-mobile#125](https://github.com/iu-alumni/iu-alumni-mobile/pull/125)) consumes this API directly.

### What ships

| Layer | Files |
|---|---|
| Migration + seed | `alembic/versions/c1d2e3f4a5b6_add_badges.py` |
| ORM | `app/models/badge.py` |
| Evaluator + strategies | `app/services/badges.py` |
| Routes (`/api/v1/badges/{,/me,/users/{id},/me/{code}/seen}`) | `app/api/routes/badges/` |
| Pydantic schemas | `app/schemas/badge.py` |
| Hooks into existing flows | `event_add_participant.py`, `approve_event.py`, `profile.py` |
| Demo seed | `scripts/seed_badge_demo.py` |

### Strategies (one per `badges.strategy` value)

- **`count_threshold`** — Networker (5 events attended), Rainmaker (20 attendees on owned event), Cross-city commuter (1 event outside home city)
- **`distinct_count`** — Host with the most (3 distinct event.location values)
- **`year_range`** — Innopolis OG (graduation_year ∈ 2014..2019)
- **`profile_completeness`** — Profile Pro (5 named fields non-null)
- **`badge_count`** — Badge Collector (10+ awarded), with recursion guard
- **`first_n`** — Pioneer (first 100 to flip `show_location=true`)
- **`per_city_first`** — Founding Host (one award per city, called explicitly by `award_founding_host(owner, event)` from the approve hook)
- **`leaderboard`** / **`manual`** — placeholders that never auto-award; reserved for follow-up tickets #6 / #9

### Hooks

| Existing route | Trigger fired |
|---|---|
| `POST /events/{id}/participants` | `event_attended` for participant |
| `POST /admin/events/approve/{id}` | `event_approved` for owner + `award_founding_host` |
| `PUT /profile/me` | `profile_updated` for user |

All wrapped in `try/except` — badge eval errors are logged and never block the underlying request.

### API

```
GET  /api/v1/badges/                     → catalog (public)
GET  /api/v1/badges/me                   → own state (earned + locked-with-progress + newly_earned)
                                            also re-evaluates every trigger on read, so refreshing
                                            the profile reflects state changes even if a hook missed
GET  /api/v1/badges/users/{alumni_id}    → public earned-only view
POST /api/v1/badges/me/{badge_code}/seen → marks seen_at for the celebratory popup
```

## Test plan

- [x] Migration applies cleanly on fresh + existing dev DBs (`alembic current` → `c1d2e3f4a5b6`)
- [x] Seed inserts 12 catalog rows, idempotent
- [x] Login + `GET /api/v1/badges/me` returns expected shape
- [x] `PUT /profile/me` (filling avatar/location/biography/grad-year/telegram + show_location) → auto-awards Pioneer + Innopolis OG + Profile Pro (verified)
- [x] `scripts.seed_badge_demo` → all 11 auto-earnable badges (Pioneer, Innopolis OG, Profile Pro, Networker, Cross-city, Host with the most, Rainmaker, Founding Host×3 with city metadata, Badge Collector via recursive trigger)
- [x] `POST .../me/{code}/seen` clears `newly_earned` for that badge
- [x] `GET /api/v1/badges/users/{id}` returns earned-only public view
- [ ] Reviewer should pull, `docker compose up`, hit the four endpoints with a JWT, run the seed script, verify the assertions in the AC above

## Deferred (separate PRs)

- **#6** Local Legend yearly leaderboard cron — `LeaderboardStrategy.compute_winners(year)` stub exists; needs the cron entry + admin recompute endpoint
- **#9** Manual admin award endpoints (`POST /admin/badges/award`/`revoke`) + Telegram DM on award
- **#14** Admin portal badges page (frontend)
- **#15** Backend tests
- **Avatar validation** — separate small ticket; the backend currently stores any string in `alumni.avatar` and the mobile decoder rejects data-URI prefixes

## Caveats baked in

- `events.location` is free-text, not an FK to `cities`. Founding Host / Host with the most / Cross-city commuter all use lowercased + trimmed exact-match comparison. Acceptable for v1; flag for later normalization (noted in `BADGES_TICKETS.md` and the docs page).
- "Founding Host" uses earliest `events.datetime` (scheduled date) as a proxy for "first in city" since `events` has no `created_at`.

---

**Closes** (auto-link on merge):
- Closes iu-alumni/iu-alumni-backend#105 — schema & migrations
- Closes iu-alumni/iu-alumni-backend#106 — evaluator framework
- Closes iu-alumni/iu-alumni-backend#107 — hook evaluator into existing flows
- Closes iu-alumni/iu-alumni-backend#108 — public badges API
- Closes iu-alumni/iu-alumni-backend#109 — first-N / per-city-first strategies
- Closes iu-alumni/iu-alumni-backend#110 — catalog seed (12 badges)
- Closes iu-alumni/iu-alumni-backend#111 — profile-derived - Closes iu-alumni/iu-alumni-backend#110 — catalog seed (12 badges) threshold strategies