### PR TITLE
Guard the Prometheus instrumentation to not run in dev mode

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -118,4 +118,5 @@ api_v1.include_router(cities_router, prefix="/cities", tags=["Cities"])
 app.include_router(api_v1)
 app.include_router(telegram_router, tags=["Telegram"])
 
-Instrumentator().instrument(app).expose(app)
+if not IS_DEVELOPMENT:
+    Instrumentator().instrument(app).expose(app)


### PR DESCRIPTION
## Description

Login returns 500, according to Claude because: "prometheus-fastapi-instrumentator 8.0.0 crashes on every request with Starlette 1.3.1 due to _IncludedRouter.path incompatibility"
Solution: guard the Prometheus instrumentation so it only runs outside dev mode.


## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️  Refactoring (no functional changes)
- [ ] 📝 Documentation update
- [x] 🔧 CI / configuration