### PR TITLE
[codex] Fix profile and auth edge cases

### DIFF
--- a/app/api/routes/admin/list_all_events.py
+++ b/app/api/routes/admin/list_all_events.py
@@ -6,14 +6,14 @@ from app.core.database import get_db
 from app.core.security import get_current_user
 from app.models.events import Event
 from app.models.users import Admin, Alumni
-from app.schemas.event import EventListItem
+from app.schemas.event import AdminEventListItem
 from app.schemas.pagination import Paginated, decode_cursor, encode_cursor
 
 
 router = APIRouter()
 
 
-@router.get("/events", response_model=Paginated[EventListItem])
+@router.get("/events", response_model=Paginated[AdminEventListItem])
 async def list_events(
     search: str | None = Query(None, description="Search by event title"),
     cursor: str | None = Query(None, description="Pagination cursor from previous response"),

--- a/app/api/routes/authentication/login_otp.py
+++ b/app/api/routes/authentication/login_otp.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime, timedelta
+import logging
 import os
 import uuid
 
@@ -20,6 +21,7 @@ from app.services.verification_service import generate_verification_code
 
 
 router = APIRouter()
+logger = logging.getLogger("iu_alumni.auth.login_otp")
 
 LOGIN_CODE_EXPIRY_MINUTES = int(os.getenv("LOGIN_CODE_EXPIRY_MINUTES", "10"))
 OTP_COOLDOWN_SECONDS = 60
@@ -36,17 +38,28 @@ async def login_otp_request(request: LoginOTPRequest, db: Session = Depends(get_
     user = db.query(Alumni).filter(Alumni.email == request.email).first()
 
     if not user:
+        logger.warning("OTP request rejected: account not found for email=%s", request.email)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="No account found with this email",
         )
 
     if not user.is_verified:
+        logger.warning(
+            "OTP request rejected: account not verified for user_id=%s email=%s",
+            user.id,
+            user.email,
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Account not verified"
         )
 
     if user.is_banned:
+        logger.warning(
+            "OTP request rejected: account banned for user_id=%s email=%s",
+            user.id,
+            user.email,
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Account is banned"
         )
@@ -62,15 +75,28 @@ async def login_otp_request(request: LoginOTPRequest, db: Session = Depends(get_
     )
     if recent and (now - recent.created_at) < timedelta(seconds=OTP_COOLDOWN_SECONDS):
         seconds_left = OTP_COOLDOWN_SECONDS - int((now - recent.created_at).total_seconds())
+        logger.info(
+            "OTP request rate-limited: user_id=%s email=%s seconds_left=%s last_created_at=%s",
+            user.id,
+            user.email,
+            seconds_left,
+            recent.created_at,
+        )
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail=f"Please wait {seconds_left} seconds before requesting a new code",
         )
 
     # Invalidate previous unused codes
-    db.query(LoginCode).filter(
+    invalidated_count = db.query(LoginCode).filter(
         LoginCode.alumni_id == user.id, LoginCode.used.is_(False)
     ).delete()
+    logger.info(
+        "OTP request cleanup: user_id=%s email=%s invalidated_unused_codes=%s",
+        user.id,
+        user.email,
+        invalidated_count,
+    )
 
     code = generate_verification_code()
     session_token = str(uuid.uuid4())
@@ -86,6 +112,13 @@ async def login_otp_request(request: LoginOTPRequest, db: Session = Depends(get_
         attempts=0,
     ))
     db.commit()
+    logger.info(
+        "OTP code persisted: user_id=%s email=%s session_token=%s expires_at=%s",
+        user.id,
+        user.email,
+        session_token,
+        now + timedelta(minutes=LOGIN_CODE_EXPIRY_MINUTES),
+    )
 
     email_sent = await send_login_code_email(
         email=user.email,
@@ -95,10 +128,22 @@ async def login_otp_request(request: LoginOTPRequest, db: Session = Depends(get_
     )
 
     if not email_sent:
+        logger.error(
+            "OTP email send failed: user_id=%s email=%s session_token=%s",
+            user.id,
+            user.email,
+            session_token,
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to send login code. Please try again later.",
         )
+    logger.info(
+        "OTP email send succeeded: user_id=%s email=%s session_token=%s",
+        user.id,
+        user.email,
+        session_token,
+    )
 
     return LoginInitResponse(
         session_token=session_token,
@@ -119,6 +164,9 @@ def login_otp_verify(request: LoginVerifyRequest, db: Session = Depends(get_db))
     )
 
     if not login_code or login_code.used:
+        logger.warning(
+            "OTP verify rejected: invalid/used session_token=%s", request.session_token
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired session",
@@ -126,6 +174,13 @@ def login_otp_verify(request: LoginVerifyRequest, db: Session = Depends(get_db))
 
     now = datetime.now(UTC).replace(tzinfo=None)
     if login_code.expires_at < now:
+        logger.warning(
+            "OTP verify rejected: expired session_token=%s alumni_id=%s expires_at=%s now=%s",
+            request.session_token,
+            login_code.alumni_id,
+            login_code.expires_at,
+            now,
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Verification code has expired",
@@ -134,6 +189,12 @@ def login_otp_verify(request: LoginVerifyRequest, db: Session = Depends(get_db))
     if login_code.attempts >= OTP_MAX_ATTEMPTS:
         login_code.used = True
         db.commit()
+        logger.warning(
+            "OTP verify blocked: max attempts reached session_token=%s alumni_id=%s attempts=%s",
+            request.session_token,
+            login_code.alumni_id,
+            login_code.attempts,
+        )
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="Too many incorrect attempts. Please request a new code",
@@ -143,6 +204,13 @@ def login_otp_verify(request: LoginVerifyRequest, db: Session = Depends(get_db))
         login_code.attempts += 1
         db.commit()
         remaining = OTP_MAX_ATTEMPTS - login_code.attempts
+        logger.warning(
+            "OTP verify failed: wrong code session_token=%s alumni_id=%s attempts=%s remaining=%s",
+            request.session_token,
+            login_code.alumni_id,
+            login_code.attempts,
+            remaining,
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=f"Incorrect verification code. {remaining} attempt(s) remaining",
@@ -150,6 +218,11 @@ def login_otp_verify(request: LoginVerifyRequest, db: Session = Depends(get_db))
 
     login_code.used = True
     db.commit()
+    logger.info(
+        "OTP verify succeeded: session_token=%s alumni_id=%s",
+        request.session_token,
+        login_code.alumni_id,
+    )
 
     user = login_code.alumni
     access_token = create_access_token(

--- a/app/api/routes/authentication/login_telegram_otp.py
+++ b/app/api/routes/authentication/login_telegram_otp.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime, timedelta
+import logging
 import os
 import uuid
 
@@ -21,6 +22,7 @@ from app.services.verification_service import generate_verification_code
 
 
 router = APIRouter()
+logger = logging.getLogger("iu_alumni.auth.login_telegram_otp")
 
 LOGIN_CODE_EXPIRY_MINUTES = int(os.getenv("LOGIN_CODE_EXPIRY_MINUTES", "10"))
 OTP_COOLDOWN_SECONDS = 60
@@ -37,22 +39,41 @@ async def login_telegram_request(request: TelegramLoginRequest, db: Session = De
     user = db.query(Alumni).filter(Alumni.email == request.email).first()
 
     if not user:
+        logger.warning(
+            "Telegram OTP request rejected: account not found for email=%s", request.email
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="No account found with this email",
         )
 
     if not user.is_verified:
+        logger.warning(
+            "Telegram OTP request rejected: account not verified user_id=%s email=%s",
+            user.id,
+            user.email,
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Account not verified"
         )
 
     if user.is_banned:
+        logger.warning(
+            "Telegram OTP request rejected: account banned user_id=%s email=%s",
+            user.id,
+            user.email,
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Account is banned"
         )
 
     if not user.is_telegram_verified:
+        logger.warning(
+            "Telegram OTP request rejected: telegram not verified user_id=%s email=%s alias=%s",
+            user.id,
+            user.email,
+            user.telegram_alias,
+        )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Telegram not verified for this account. Please verify your Telegram account via your profile settings.",
@@ -64,6 +85,12 @@ async def login_telegram_request(request: TelegramLoginRequest, db: Session = De
         .first()
     )
     if not tg_user:
+        logger.warning(
+            "Telegram OTP request rejected: alias has no bot chat user_id=%s email=%s alias=%s",
+            user.id,
+            user.email,
+            user.telegram_alias,
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Telegram bot not started. Please open the bot and send /start first.",
@@ -79,14 +106,27 @@ async def login_telegram_request(request: TelegramLoginRequest, db: Session = De
     )
     if recent and (now - recent.created_at) < timedelta(seconds=OTP_COOLDOWN_SECONDS):
         seconds_left = OTP_COOLDOWN_SECONDS - int((now - recent.created_at).total_seconds())
+        logger.info(
+            "Telegram OTP rate-limited: user_id=%s email=%s seconds_left=%s last_created_at=%s",
+            user.id,
+            user.email,
+            seconds_left,
+            recent.created_at,
+        )
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail=f"Please wait {seconds_left} seconds before requesting a new code",
         )
 
-    db.query(LoginCode).filter(
+    invalidated_count = db.query(LoginCode).filter(
         LoginCode.alumni_id == user.id, LoginCode.used.is_(False)
     ).delete()
+    logger.info(
+        "Telegram OTP cleanup: user_id=%s email=%s invalidated_unused_codes=%s",
+        user.id,
+        user.email,
+        invalidated_count,
+    )
 
     code = generate_verification_code()
     session_token = str(uuid.uuid4())
@@ -102,6 +142,13 @@ async def login_telegram_request(request: TelegramLoginRequest, db: Session = De
         attempts=0,
     ))
     db.commit()
+    logger.info(
+        "Telegram OTP code persisted: user_id=%s email=%s session_token=%s expires_at=%s",
+        user.id,
+        user.email,
+        session_token,
+        now + timedelta(minutes=LOGIN_CODE_EXPIRY_MINUTES),
+    )
 
     sent = await telegram_service.send_login_code(
         chat_id=tg_user.chat_id,
@@ -111,10 +158,24 @@ async def login_telegram_request(request: TelegramLoginRequest, db: Session = De
     )
 
     if not sent:
+        logger.error(
+            "Telegram OTP send failed: user_id=%s email=%s alias=%s session_token=%s",
+            user.id,
+            user.email,
+            user.telegram_alias,
+            session_token,
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to send Telegram code. Please try again later.",
         )
+    logger.info(
+        "Telegram OTP send succeeded: user_id=%s email=%s alias=%s session_token=%s",
+        user.id,
+        user.email,
+        user.telegram_alias,
+        session_token,
+    )
 
     return LoginInitResponse(
         session_token=session_token,
@@ -132,6 +193,10 @@ def login_telegram_verify(request: TelegramVerifyRequest, db: Session = Depends(
     )
 
     if not login_code or login_code.used:
+        logger.warning(
+            "Telegram OTP verify rejected: invalid/used session_token=%s",
+            request.session_token,
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired session",
@@ -139,6 +204,13 @@ def login_telegram_verify(request: TelegramVerifyRequest, db: Session = Depends(
 
     now = datetime.now(UTC).replace(tzinfo=None)
     if login_code.expires_at < now:
+        logger.warning(
+            "Telegram OTP verify rejected: expired session_token=%s alumni_id=%s expires_at=%s now=%s",
+            request.session_token,
+            login_code.alumni_id,
+            login_code.expires_at,
+            now,
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Verification code has expired",
@@ -147,6 +219,12 @@ def login_telegram_verify(request: TelegramVerifyRequest, db: Session = Depends(
     if login_code.attempts >= OTP_MAX_ATTEMPTS:
         login_code.used = True
         db.commit()
+        logger.warning(
+            "Telegram OTP verify blocked: max attempts session_token=%s alumni_id=%s attempts=%s",
+            request.session_token,
+            login_code.alumni_id,
+            login_code.attempts,
+        )
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="Too many incorrect attempts. Please request a new code",
@@ -156,6 +234,13 @@ def login_telegram_verify(request: TelegramVerifyRequest, db: Session = Depends(
         login_code.attempts += 1
         db.commit()
         remaining = OTP_MAX_ATTEMPTS - login_code.attempts
+        logger.warning(
+            "Telegram OTP verify failed: wrong code session_token=%s alumni_id=%s attempts=%s remaining=%s",
+            request.session_token,
+            login_code.alumni_id,
+            login_code.attempts,
+            remaining,
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=f"Incorrect verification code. {remaining} attempt(s) remaining",
@@ -163,6 +248,11 @@ def login_telegram_verify(request: TelegramVerifyRequest, db: Session = Depends(
 
     login_code.used = True
     db.commit()
+    logger.info(
+        "Telegram OTP verify succeeded: session_token=%s alumni_id=%s",
+        request.session_token,
+        login_code.alumni_id,
+    )
 
     user = login_code.alumni
     access_token = create_access_token(

--- a/app/api/routes/authentication/password_reset_request.py
+++ b/app/api/routes/authentication/password_reset_request.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime, timedelta
+import logging
 import os
 import uuid
 
@@ -13,6 +14,7 @@ from app.services.email_service import send_password_reset_email
 
 
 router = APIRouter()
+logger = logging.getLogger("iu_alumni.auth.password_reset")
 
 PASSWORD_RESET_EXPIRY_MINUTES = int(os.getenv("PASSWORD_RESET_EXPIRY_MINUTES", "30"))
 PASSWORD_RESET_COOLDOWN_SECONDS = 60
@@ -30,6 +32,11 @@ async def password_reset_request(
     Rate-limited to one request per 60 seconds per account.
     """
     user = db.query(Alumni).filter(Alumni.email == request.email).first()
+    logger.info(
+        "Password reset requested for email=%s user_exists=%s",
+        request.email,
+        bool(user),
+    )
 
     if user:
         now = datetime.now(UTC).replace(tzinfo=None)
@@ -45,14 +52,30 @@ async def password_reset_request(
             .first()
         )
         if recent and (now - recent.created_at) < timedelta(seconds=PASSWORD_RESET_COOLDOWN_SECONDS):
+            seconds_left = PASSWORD_RESET_COOLDOWN_SECONDS - int(
+                (now - recent.created_at).total_seconds()
+            )
+            logger.info(
+                "Password reset rate-limited: user_id=%s email=%s seconds_left=%s last_created_at=%s",
+                user.id,
+                user.email,
+                seconds_left,
+                recent.created_at,
+            )
             # Still return 200 — don't reveal whether email exists or is rate-limited
             return {"message": "If that email is registered, a reset link has been sent"}
 
         # Invalidate any existing unused tokens
-        db.query(PasswordResetToken).filter(
+        invalidated_count = db.query(PasswordResetToken).filter(
             PasswordResetToken.alumni_id == user.id,
             PasswordResetToken.used.is_(False),
         ).delete()
+        logger.info(
+            "Password reset cleanup: user_id=%s email=%s invalidated_unused_tokens=%s",
+            user.id,
+            user.email,
+            invalidated_count,
+        )
 
         token = str(uuid.uuid4())
         reset_token = PasswordResetToken(
@@ -66,6 +89,13 @@ async def password_reset_request(
         )
         db.add(reset_token)
         db.commit()
+        logger.info(
+            "Password reset token persisted: user_id=%s email=%s token_id=%s expires_at=%s",
+            user.id,
+            user.email,
+            reset_token.id,
+            reset_token.expires_at,
+        )
 
         reset_link = f"{FRONTEND_URL}/reset-password?token={token}"
         background_tasks.add_task(
@@ -74,6 +104,17 @@ async def password_reset_request(
             first_name=user.first_name,
             reset_link=reset_link,
             expiry_minutes=PASSWORD_RESET_EXPIRY_MINUTES,
+        )
+        logger.info(
+            "Password reset email scheduled in background: user_id=%s email=%s token_id=%s",
+            user.id,
+            user.email,
+            reset_token.id,
+        )
+    else:
+        logger.info(
+            "Password reset completed with opaque response for non-existing email=%s",
+            request.email,
         )
 
     return {"message": "If that email is registered, a reset link has been sent"}

--- a/app/api/routes/authentication/resend_verification.py
+++ b/app/api/routes/authentication/resend_verification.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
@@ -14,6 +15,7 @@ from app.services.verification_service import (
 
 
 BACKEND_URL = os.getenv("BACKEND_URL", "")
+logger = logging.getLogger("iu_alumni.auth.resend_verification")
 
 router = APIRouter()
 
@@ -27,19 +29,33 @@ async def resend_verification_link(
     """
     Resend email verification link. Rate-limited to once per 60 seconds.
     """
+    logger.info("Resend verification requested for email=%s", request.email)
     can_resend, message, _alumni_id = can_resend_verification(db, request.email)
 
     if not can_resend:
+        logger.warning(
+            "Resend verification denied for email=%s reason=%s", request.email, message
+        )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message)
 
     user = db.query(Alumni).filter(Alumni.email == request.email).first()
     if not user:
+        logger.warning(
+            "Resend verification failed: user not found after can_resend check email=%s",
+            request.email,
+        )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         )
 
     _, token = create_link_verification_record(db, user.id)
     verify_url = f"{BACKEND_URL}/api/v1/auth/verify?token={token}"
+    logger.info(
+        "Resend verification token issued: user_id=%s email=%s verification_url_base=%s",
+        user.id,
+        user.email,
+        BACKEND_URL,
+    )
 
     background_tasks.add_task(
         send_verification_link_email,
@@ -47,6 +63,10 @@ async def resend_verification_link(
         user.first_name,
         verify_url,
     )
+    logger.info(
+        "Resend verification email scheduled in background: user_id=%s email=%s",
+        user.id,
+        user.email,
+    )
 
     return {"message": "A new verification link has been sent to your email", "email": user.email}
-

--- a/app/api/routes/profile/get_profiles.py
+++ b/app/api/routes/profile/get_profiles.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy import or_
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
@@ -15,8 +15,12 @@ router = APIRouter()
 @router.get("/all", response_model=Paginated[ProfileListItem])
 def get_profiles(
     search: str | None = Query(None, description="Search by name"),
-    location: str | None = Query(None, description="Filter by exact location string, e.g. 'Russia, Innopolis'"),
-    cursor: str | None = Query(None, description="Pagination cursor from previous response"),
+    location: str | None = Query(
+        None, description="Filter by exact location string, e.g. 'Russia, Innopolis'"
+    ),
+    cursor: str | None = Query(
+        None, description="Pagination cursor from previous response"
+    ),
     limit: int = Query(50, ge=1, le=100),
     db: Session = Depends(get_db),
     current_user: Alumni | Admin = Depends(get_current_user),
@@ -43,8 +47,13 @@ def get_profiles(
         )
 
     if location:
-        # ix_alumni_location B-tree index makes this an index seek.
-        query = query.filter(Alumni.location == location)
+        # Keep city-detail lists aligned with /profile/map pin counts.
+        query = query.filter(
+            func.lower(Alumni.location) == location.lower(),
+            Alumni.show_location.is_(True),
+            Alumni.is_verified.is_(True),
+            Alumni.is_banned.is_(False),
+        )
 
     if cursor:
         c = decode_cursor(cursor)

--- a/app/api/routes/profile/profile.py
+++ b/app/api/routes/profile/profile.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
@@ -8,6 +8,16 @@ from app.schemas.profile import ProfileResponse, ProfileUpdateRequest
 
 
 router = APIRouter()
+
+
+def _clean_required_name(value: str, field_name: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"{field_name} is required",
+        )
+    return cleaned
 
 
 @router.get("/me", response_model=ProfileResponse)
@@ -39,10 +49,14 @@ def update_profile(
         )
     # Update fields if provided
     if profile_data.first_name is not None:
-        current_user.first_name = profile_data.first_name
+        current_user.first_name = _clean_required_name(
+            profile_data.first_name, "First name"
+        )
 
     if profile_data.last_name is not None:
-        current_user.last_name = profile_data.last_name
+        current_user.last_name = _clean_required_name(
+            profile_data.last_name, "Last name"
+        )
 
     if profile_data.graduation_year is not None:
         current_user.graduation_year = profile_data.graduation_year
@@ -63,7 +77,7 @@ def update_profile(
             current_user.is_telegram_verified = False
 
     if profile_data.avatar is not None:
-        current_user.avatar = profile_data.avatar
+        current_user.avatar = profile_data.avatar or None
 
     db.commit()
     db.refresh(current_user)

--- a/app/schemas/event.py
+++ b/app/schemas/event.py
@@ -39,6 +39,12 @@ class EventListItem(BaseModel):
     approved: bool | None = None
 
 
+class AdminEventListItem(EventListItem):
+    """Admin event list item — includes cover for thumbnail display."""
+
+    cover: str | None = None
+
+
 class CreateEventRequest(BaseModel):
     title: str
     description: str

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -46,6 +46,11 @@ async def send_login_code_email(
 ) -> bool:
     """Send 2FA login code email."""
     try:
+        logger.info(
+            "Preparing login code email to %s with expiry_minutes=%s",
+            email,
+            expiry_minutes,
+        )
         message = MessageSchema(
             subject="IU Alumni — Your login code",
             recipients=[email],
@@ -57,6 +62,7 @@ async def send_login_code_email(
             subtype=MessageType.html,
         )
         await fm.send_message(message, template_name="login_code.html")
+        logger.info("Login code email sent successfully to %s", email)
         return True
     except Exception:
         logger.exception("Failed to send login code email to %s", email)
@@ -68,6 +74,11 @@ async def send_password_reset_email(
 ) -> bool:
     """Send password reset link email."""
     try:
+        logger.info(
+            "Preparing password reset email to %s with expiry_minutes=%s",
+            email,
+            expiry_minutes,
+        )
         message = MessageSchema(
             subject="IU Alumni — Reset your password",
             recipients=[email],
@@ -79,6 +90,7 @@ async def send_password_reset_email(
             subtype=MessageType.html,
         )
         await fm.send_message(message, template_name="password_reset.html")
+        logger.info("Password reset email sent successfully to %s", email)
         return True
     except Exception:
         logger.exception("Failed to send password reset email to %s", email)
@@ -132,6 +144,11 @@ async def send_manual_verification_notification(
         bool: True if email sent successfully, False otherwise
     """
     try:
+        logger.info(
+            "Preparing manual verification notification to admin=%s for user_email=%s",
+            admin_email,
+            user_email,
+        )
         message = MessageSchema(
             subject="Manual Verification Request — IU Alumni",
             recipients=[admin_email],
@@ -142,6 +159,10 @@ async def send_manual_verification_notification(
             subtype=MessageType.html,
         )
         await fm.send_message(message, template_name="manual_verification.html")
+        logger.info(
+            "Manual verification notification email sent successfully to admin=%s",
+            admin_email,
+        )
         return True
     except Exception:
         logger.exception("Failed to send admin notification to %s", admin_email)
@@ -160,6 +181,7 @@ async def send_verification_success_email(email: EmailStr, first_name: str) -> b
         bool: True if email sent successfully, False otherwise
     """
     try:
+        logger.info("Preparing verification success email to %s", email)
         message = MessageSchema(
             subject="Account Verified — IU Alumni Platform",
             recipients=[email],
@@ -167,6 +189,7 @@ async def send_verification_success_email(email: EmailStr, first_name: str) -> b
             subtype=MessageType.html,
         )
         await fm.send_message(message, template_name="verification_success.html")
+        logger.info("Verification success email sent successfully to %s", email)
         return True
     except Exception:
         logger.exception("Failed to send verification success email to %s", email)
@@ -178,6 +201,11 @@ async def send_verification_link_email(
 ) -> bool:
     """Send link-based registration email verification."""
     try:
+        logger.info(
+            "Preparing verification link email to %s with expiry_hours=%s",
+            email,
+            expiry_hours,
+        )
         message = MessageSchema(
             subject="Verify your IU Alumni account",
             recipients=[email],
@@ -201,6 +229,12 @@ async def send_telegram_verification_email(
 ) -> bool:
     """Send link-based Telegram account verification email."""
     try:
+        logger.info(
+            "Preparing Telegram verification email to %s alias=%s expiry_hours=%s",
+            email,
+            telegram_alias,
+            expiry_hours,
+        )
         message = MessageSchema(
             subject="Confirm your Telegram account — IU Alumni",
             recipients=[email],

--- a/app/services/verification_service.py
+++ b/app/services/verification_service.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import logging
 import os
 import random
 import secrets
@@ -12,6 +13,7 @@ from app.models.users import Alumni
 
 
 VERIFICATION_LINK_EXPIRY_HOURS = int(os.getenv("VERIFICATION_LINK_EXPIRY_HOURS", "24"))
+logger = logging.getLogger("iu_alumni.verification_service")
 
 
 def generate_verification_code() -> str:
@@ -39,6 +41,11 @@ def create_link_verification_record(
     )
 
     if existing:
+        logger.info(
+            "Refreshing verification link record for alumni_id=%s expires_in_hours=%s",
+            alumni_id,
+            VERIFICATION_LINK_EXPIRY_HOURS,
+        )
         existing.verification_token = token
         existing.verification_token_expires = expires
         existing.verification_requested_at = now
@@ -58,6 +65,11 @@ def create_link_verification_record(
     db.add(record)
     db.commit()
     db.refresh(record)
+    logger.info(
+        "Created verification link record for alumni_id=%s expires_in_hours=%s",
+        alumni_id,
+        VERIFICATION_LINK_EXPIRY_HOURS,
+    )
     return record, token
 
 
@@ -195,11 +207,18 @@ def admin_verify_user(db: Session, email: str) -> tuple[bool, str]:
 
 def can_resend_verification(db: Session, email: str) -> tuple[bool, str, str | None]:
     """Check if user can request a new verification link."""
+    logger.info("Checking resend verification eligibility for email=%s", email)
     alumni = db.query(Alumni).filter(Alumni.email == email).first()
     if not alumni:
+        logger.warning("Resend verification eligibility failed: user not found email=%s", email)
         return False, "User not found", None
 
     if alumni.is_verified:
+        logger.info(
+            "Resend verification eligibility failed: already verified user_id=%s email=%s",
+            alumni.id,
+            alumni.email,
+        )
         return False, "User already verified", None
 
     verification = (
@@ -212,12 +231,24 @@ def can_resend_verification(db: Session, email: str) -> tuple[bool, str, str | N
         time_since_last_request = datetime.utcnow() - verification.verification_requested_at
         if time_since_last_request < timedelta(seconds=60):
             seconds_to_wait = 60 - time_since_last_request.total_seconds()
+            logger.info(
+                "Resend verification rate-limited: user_id=%s email=%s seconds_left=%s last_request_at=%s",
+                alumni.id,
+                alumni.email,
+                int(seconds_to_wait),
+                verification.verification_requested_at,
+            )
             return (
                 False,
                 f"Please wait {int(seconds_to_wait)} seconds before requesting a new link",
                 None,
             )
 
+    logger.info(
+        "Resend verification eligibility passed: user_id=%s email=%s",
+        alumni.id,
+        alumni.email,
+    )
     return True, "Can resend", alumni.id
 
 
@@ -242,4 +273,3 @@ def admin_unverify_user(db: Session, email: str) -> tuple[bool, str]:
 
     db.commit()
     return True, "User unverified successfully"
-

--- a/tests/test_profile_routes.py
+++ b/tests/test_profile_routes.py
@@ -1,0 +1,84 @@
+from fastapi import HTTPException
+import pytest
+
+from app.api.routes.profile.get_profiles import get_profiles
+from app.api.routes.profile.profile import update_profile
+from app.models.users import Alumni
+from app.schemas.profile import ProfileUpdateRequest
+
+
+def _alumni(
+    user_id: str,
+    *,
+    location: str | None = "Russia, Saint Petersburg",
+    show_location: bool = True,
+    is_verified: bool = True,
+    is_banned: bool = False,
+) -> Alumni:
+    return Alumni(
+        id=user_id,
+        email=f"{user_id}@innopolis.university",
+        first_name="First",
+        last_name="Last",
+        graduation_year="2024",
+        location=location,
+        biography=None,
+        show_location=show_location,
+        telegram_alias=None,
+        avatar="avatar-data",
+        is_verified=is_verified,
+        is_banned=is_banned,
+    )
+
+
+def test_update_profile_rejects_blank_required_names(db_session):
+    user = _alumni("user-1")
+    db_session.add(user)
+    db_session.commit()
+
+    with pytest.raises(HTTPException) as exc_info:
+        update_profile(
+            ProfileUpdateRequest(first_name="   "),
+            current_user=user,
+            db=db_session,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "First name is required"
+
+
+def test_update_profile_trims_names_and_clears_avatar(db_session):
+    user = _alumni("user-1")
+    db_session.add(user)
+    db_session.commit()
+
+    updated = update_profile(
+        ProfileUpdateRequest(first_name="  Ada  ", last_name="  Lovelace  ", avatar=""),
+        current_user=user,
+        db=db_session,
+    )
+
+    assert updated.first_name == "Ada"
+    assert updated.last_name == "Lovelace"
+    assert updated.avatar is None
+
+
+def test_get_profiles_location_filter_matches_map_visibility_rules(db_session):
+    visible = _alumni("visible")
+    hidden = _alumni("hidden", show_location=False)
+    unverified = _alumni("unverified", is_verified=False)
+    banned = _alumni("banned", is_banned=True)
+    other_city = _alumni("other-city", location="Russia, Innopolis")
+    db_session.add_all([visible, hidden, unverified, banned, other_city])
+    db_session.commit()
+
+    page = get_profiles(
+        search=None,
+        location="russia, saint petersburg",
+        cursor=None,
+        limit=50,
+        db=db_session,
+        current_user=visible,
+    )
+
+    assert [profile.id for profile in page.items] == ["visible"]


### PR DESCRIPTION
## Summary
- Reject blank first and last names in profile updates while preserving trimmed values.
- Align location-filtered profile lists with the public map visibility rules.
- Add backend coverage for profile validation, avatar clearing, and map/list visibility alignment.
- Include the local auth/email/event API updates already present in this worktree.

Fixes #102
Fixes #103

## Validation
- `.venv/bin/ruff check app/api/routes/profile/profile.py app/api/routes/profile/get_profiles.py tests/test_profile_routes.py`
- `.venv/bin/python -m py_compile app/api/routes/profile/profile.py app/api/routes/profile/get_profiles.py tests/test_profile_routes.py`
- `pytest` not run: pytest is not installed in the backend virtualenv.