### PR TITLE
[codex] Fix backend verification and event validation bugs

### DIFF
--- a/app/api/routes/authentication/register.py
+++ b/app/api/routes/authentication/register.py
@@ -1,10 +1,11 @@
 import logging
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.core.security import get_password_hash, get_random_token
+from app.core.url_utils import build_absolute_url
 from app.models.users import Admin, Alumni
 from app.schemas.auth import RegisterRequest
 from app.services.email_hash_service import is_email_allowed
@@ -31,6 +32,7 @@ router = APIRouter()
 async def register(
     request: RegisterRequest,
     background_tasks: BackgroundTasks,
+    http_request: Request,
     db: Session = Depends(get_db),
 ):
     """
@@ -70,7 +72,11 @@ async def register(
     if email_allowed and not request.manual_verification:
         # Auto verification: send confirmation link
         _, token = create_link_verification_record(db, new_user.id)
-        verify_url = f"{BACKEND_URL}/api/v1/auth/verify?token={token}"
+        verify_url = build_absolute_url(
+            f"/api/v1/auth/verify?token={token}",
+            request=http_request,
+            configured_base=BACKEND_URL,
+        )
         logger.info(f"Sending verification link to {new_user.email}")
         email_sent = await send_verification_link_email(
             new_user.email, new_user.first_name, verify_url

--- a/app/api/routes/authentication/resend_verification.py
+++ b/app/api/routes/authentication/resend_verification.py
@@ -1,10 +1,11 @@
 import logging
 import os
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
+from app.core.url_utils import build_absolute_url
 from app.models.users import Alumni
 from app.schemas.auth import ResendVerificationRequest
 from app.services.email_service import send_verification_link_email
@@ -23,7 +24,7 @@ router = APIRouter()
 @router.post("/resend-verification", status_code=status.HTTP_200_OK)
 async def resend_verification_link(
     request: ResendVerificationRequest,
-    background_tasks: BackgroundTasks,
+    http_request: Request,
     db: Session = Depends(get_db),
 ):
     """
@@ -49,7 +50,11 @@ async def resend_verification_link(
         )
 
     _, token = create_link_verification_record(db, user.id)
-    verify_url = f"{BACKEND_URL}/api/v1/auth/verify?token={token}"
+    verify_url = build_absolute_url(
+        f"/api/v1/auth/verify?token={token}",
+        request=http_request,
+        configured_base=BACKEND_URL,
+    )
     logger.info(
         "Resend verification token issued: user_id=%s email=%s verification_url_base=%s",
         user.id,
@@ -57,14 +62,18 @@ async def resend_verification_link(
         BACKEND_URL,
     )
 
-    background_tasks.add_task(
-        send_verification_link_email,
+    email_sent = await send_verification_link_email(
         user.email,
         user.first_name,
         verify_url,
     )
+    if not email_sent:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to send verification email. Please try again later.",
+        )
     logger.info(
-        "Resend verification email scheduled in background: user_id=%s email=%s",
+        "Resend verification email sent: user_id=%s email=%s",
         user.id,
         user.email,
     )

--- a/app/api/routes/events/update_event.py
+++ b/app/api/routes/events/update_event.py
@@ -71,7 +71,7 @@ async def update_event(
         event.is_online = event_data.is_online
         changes["is_online"] = event_data.is_online
 
-    if event_data.cover is not None:
+    if "cover" in event_data.model_fields_set:
         event.cover = event_data.cover
 
     # Commit changes

--- a/app/core/url_utils.py
+++ b/app/core/url_utils.py
@@ -1,0 +1,6 @@
+from fastapi import Request
+
+
+def build_absolute_url(path: str, *, request: Request, configured_base: str = "") -> str:
+    base_url = configured_base.strip() or str(request.base_url)
+    return f"{base_url.rstrip('/')}/{path.lstrip('/')}"

--- a/app/schemas/event.py
+++ b/app/schemas/event.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any
 
 import dateutil.parser
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
 
 
 class CoverResponse(BaseModel):
@@ -46,13 +46,30 @@ class AdminEventListItem(EventListItem):
 
 
 class CreateEventRequest(BaseModel):
-    title: str
-    description: str
-    location: str
+    title: str = Field(..., min_length=1)
+    description: str = Field(..., min_length=1)
+    location: str = Field(..., min_length=1)
     datetime: datetime
     cost: float
     is_online: bool
     cover: str | None = None
+
+    @field_validator("title", "description", "location", mode="before")
+    @classmethod
+    def validate_required_text(cls, value: str) -> str:
+        if not isinstance(value, str):
+            raise ValueError("Field must be text")
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("Field cannot be blank")
+        return stripped
+
+    @field_validator("cover", mode="before")
+    @classmethod
+    def normalize_cover(cls, value: str | None) -> str | None:
+        if value == "":
+            return None
+        return value
 
 
 class CreateEventResponse(BaseModel):
@@ -67,6 +84,25 @@ class UpdateEventRequest(BaseModel):
     cost: float | None = None
     is_online: bool | None = None
     cover: str | None = None
+
+    @field_validator("title", "description", "location", mode="before")
+    @classmethod
+    def validate_optional_text(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise ValueError("Field must be text")
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("Field cannot be blank")
+        return stripped
+
+    @field_validator("cover", mode="before")
+    @classmethod
+    def normalize_cover(cls, value: str | None) -> str | None:
+        if value == "":
+            return None
+        return value
 
     def __init__(self, **data):
         if (

--- a/tests/test_auth_register.py
+++ b/tests/test_auth_register.py
@@ -9,6 +9,12 @@ from app.api.routes.authentication.register import register
 from app.schemas.auth import RegisterRequest
 
 
+def _http_request(base_url: str = "https://api.example.test/"):
+    request = MagicMock()
+    request.base_url = base_url
+    return request
+
+
 class TestRegister:
     """Test cases for user registration."""
 
@@ -25,7 +31,7 @@ class TestRegister:
         mock_record = MagicMock()
         mock_create_link_verification_record.return_value = (mock_record, "test_token")
 
-        mocker.patch(
+        mock_send_verification_link_email = mocker.patch(
             "app.api.routes.authentication.register.send_verification_link_email",
             return_value=True,
         )
@@ -40,7 +46,12 @@ class TestRegister:
         )
 
         background_tasks = MagicMock()
-        result = await register(request, background_tasks, db_session)
+        result = await register(
+            request,
+            background_tasks,
+            _http_request(),
+            db_session,
+        )
 
         assert result["message"] == "Registration successful. Please check your email for a confirmation link."
         assert result["email"] == "john.doe@innopolis.university"
@@ -58,6 +69,11 @@ class TestRegister:
         assert user.is_banned is False
         assert user.hashed_password == "hashed_password"
         assert user.is_verified is False
+        mock_send_verification_link_email.assert_awaited_once_with(
+            "john.doe@innopolis.university",
+            "John",
+            "https://api.example.test/api/v1/auth/verify?token=test_token",
+        )
 
     @pytest.mark.asyncio
     async def test_register_email_already_exists(self, db_session):
@@ -87,7 +103,12 @@ class TestRegister:
         background_tasks = MagicMock()
 
         with pytest.raises(HTTPException) as exc_info:
-            await register(request, background_tasks, db_session)
+            await register(
+                request,
+                background_tasks,
+                _http_request(),
+                db_session,
+            )
 
         assert exc_info.value.status_code == 400
         assert exc_info.value.detail == "Email already registered"
@@ -117,7 +138,12 @@ class TestRegister:
         )
 
         background_tasks = MagicMock()
-        result = await register(request, background_tasks, db_session)
+        result = await register(
+            request,
+            background_tasks,
+            _http_request(),
+            db_session,
+        )
 
         assert result["message"] == (
             "Registration successful. Your email is not in our graduates list. "

--- a/tests/test_event_update.py
+++ b/tests/test_event_update.py
@@ -334,6 +334,45 @@ async def test_update_event_cover(db_session):
 
 
 @pytest.mark.asyncio
+async def test_update_event_clears_cover(db_session):
+    user = Alumni(
+        id="user123",
+        email="user@innopolis.university",
+        first_name="Test",
+        last_name="User",
+        graduation_year="2025"
+    )
+    db_session.add(user)
+
+    event = Event(
+        id="event123",
+        title="Test Event",
+        description="Description",
+        owner_id="user123",
+        location="Room 101",
+        datetime=datetime(2025, 1, 1, 10, 0, 0),
+        cost=0.0,
+        is_online=False,
+        participants_ids=[],
+        approved=True,
+        cover="https://example.com/image.jpg"
+    )
+    db_session.add(event)
+    db_session.commit()
+
+    request = UpdateEventRequest(cover="")
+
+    result = await update_event(
+        event_id="event123",
+        event_data=request,
+        db=db_session,
+        current_user=user
+    )
+
+    assert result.cover is None
+
+
+@pytest.mark.asyncio
 async def test_update_event_admin_success(db_session):
     admin = Admin(
         id="admin123",

--- a/tests/test_resend_verification.py
+++ b/tests/test_resend_verification.py
@@ -1,0 +1,81 @@
+from unittest.mock import MagicMock
+
+from fastapi import HTTPException
+import pytest
+
+from app.api.routes.authentication.resend_verification import resend_verification_link
+from app.models.users import Alumni
+from app.schemas.auth import ResendVerificationRequest
+
+
+def _http_request(base_url: str = "https://api.example.test/"):
+    request = MagicMock()
+    request.base_url = base_url
+    return request
+
+
+def _alumni() -> Alumni:
+    return Alumni(
+        id="user-1",
+        email="user@innopolis.university",
+        hashed_password="hash",
+        first_name="Ada",
+        last_name="Lovelace",
+        graduation_year="2024",
+        is_verified=False,
+        is_banned=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resend_verification_uses_absolute_link(db_session, mocker):
+    user = _alumni()
+    db_session.add(user)
+    db_session.commit()
+
+    mocker.patch(
+        "app.services.verification_service.secrets.token_urlsafe",
+        return_value="test-token",
+    )
+    send_email = mocker.patch(
+        "app.api.routes.authentication.resend_verification.send_verification_link_email",
+        return_value=True,
+    )
+
+    result = await resend_verification_link(
+        ResendVerificationRequest(email=user.email),
+        _http_request(),
+        db_session,
+    )
+
+    assert result == {
+        "message": "A new verification link has been sent to your email",
+        "email": user.email,
+    }
+    send_email.assert_awaited_once_with(
+        user.email,
+        user.first_name,
+        "https://api.example.test/api/v1/auth/verify?token=test-token",
+    )
+
+
+@pytest.mark.asyncio
+async def test_resend_verification_reports_email_send_failure(db_session, mocker):
+    user = _alumni()
+    db_session.add(user)
+    db_session.commit()
+
+    mocker.patch(
+        "app.api.routes.authentication.resend_verification.send_verification_link_email",
+        return_value=False,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await resend_verification_link(
+            ResendVerificationRequest(email=user.email),
+            _http_request(),
+            db_session,
+        )
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "Failed to send verification email. Please try again later."

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -9,6 +9,7 @@ from app.schemas.auth import (
     PasswordResetConfirmSchema,
     RegisterRequest,
 )
+from app.schemas.event import CreateEventRequest, UpdateEventRequest
 
 
 class TestAuthSchemas:
@@ -316,3 +317,52 @@ class TestAuthSchemas:
         response = TokenResponse(**data)
         assert response.access_token == "token123"
         assert response.token_type == "bearer"
+
+
+class TestEventSchemas:
+    """Test cases for event schemas."""
+
+    def test_create_event_rejects_blank_required_text(self):
+        """Test CreateEventRequest rejects whitespace-only text fields."""
+        data = {
+            "title": "   ",
+            "description": "Description",
+            "location": "Room 101",
+            "datetime": "2025-01-01T10:00:00",
+            "cost": 0,
+            "is_online": False,
+        }
+
+        with pytest.raises(ValidationError) as exc_info:
+            CreateEventRequest(**data)
+        assert "title" in str(exc_info.value)
+
+    def test_create_event_trims_text_and_normalizes_empty_cover(self):
+        """Test CreateEventRequest trims text fields and treats blank cover as absent."""
+        request = CreateEventRequest(
+            title="  Workshop  ",
+            description="  Learn things  ",
+            location="  Room 101  ",
+            datetime="2025-01-01T10:00:00",
+            cost=0,
+            is_online=False,
+            cover="",
+        )
+
+        assert request.title == "Workshop"
+        assert request.description == "Learn things"
+        assert request.location == "Room 101"
+        assert request.cover is None
+
+    def test_update_event_rejects_blank_required_text_when_present(self):
+        """Test UpdateEventRequest rejects blank editable text fields."""
+        with pytest.raises(ValidationError) as exc_info:
+            UpdateEventRequest(description="  ")
+        assert "description" in str(exc_info.value)
+
+    def test_update_event_normalizes_empty_cover(self):
+        """Test UpdateEventRequest uses blank cover as an explicit clear request."""
+        request = UpdateEventRequest(cover="")
+
+        assert request.cover is None
+        assert "cover" in request.model_fields_set


### PR DESCRIPTION
## Summary
- Build absolute email verification links from `BACKEND_URL` or the request base URL fallback so emails no longer contain endpoint-only links.
- Make resend verification report email-send failures instead of returning success before a background task can fail.
- Reject blank event title, description, and location values, trimming valid values before persistence.
- Allow event cover deletion by treating an explicitly provided blank cover as a clear request.
- Add focused tests for registration/resend verification links, resend failure behavior, event schema validation, and cover clearing.

Fixes #85
Fixes #100
Fixes #104
Related to #99

## Notes
- #56 appears resolved by reporter comment and has no current repro details.
- #96 appears to require environment/network diagnostics; this PR does not claim to fix Telegram network reachability.

## Validation
- `.venv/bin/ruff check app/api/routes/authentication/register.py app/api/routes/authentication/resend_verification.py app/api/routes/events/update_event.py app/schemas/event.py app/core/url_utils.py tests/test_auth_register.py tests/test_resend_verification.py tests/test_schemas.py tests/test_event_update.py`
- `.venv/bin/python -m py_compile app/api/routes/authentication/register.py app/api/routes/authentication/resend_verification.py app/api/routes/events/update_event.py app/schemas/event.py app/core/url_utils.py tests/test_auth_register.py tests/test_resend_verification.py tests/test_schemas.py tests/test_event_update.py`
- `pytest` not run locally: pytest is not installed in the backend virtualenv.