### PR TITLE
feat(badges): revoke ineligible badges when leaving an event

### DIFF
--- a/app/api/routes/events/event_remove_participant.py
+++ b/app/api/routes/events/event_remove_participant.py
@@ -60,6 +60,24 @@ async def remove_participant(
     try:
         db.commit()
         db.refresh(event)
+
+        # Revoke any of the leaving participant's badges whose criteria no
+        # longer hold (Networker, Cross-city commuter, etc.) plus a cascade
+        # check for the event owner (Rainmaker if attendance dropped below
+        # 20). Failure-tolerant — never blocks the leave response.
+        try:
+            from app.services.badges import revoke_ineligible
+
+            revoke_ineligible(db, participant)
+            owner = db.query(Alumni).filter(Alumni.id == event.owner_id).first()
+            if owner is not None and owner.id != participant.id:
+                revoke_ineligible(db, owner)
+        except Exception as revoke_err:
+            import logging
+            logging.getLogger("iu_alumni").error(
+                "badge revocation failed on event_left: %s", revoke_err
+            )
+
         return {"message": "Successfully left the event"}
     except Exception as e:
         db.rollback()

--- a/app/services/badges.py
+++ b/app/services/badges.py
@@ -255,6 +255,63 @@ def _award(
 # ─────────────────────────── public API ────────────────────────────────────
 
 
+# Strategies whose criteria are one-way / historical / externally-owned.
+# Even if `_should_award` returns False now (e.g. a user edits their profile
+# and the raw signal disappears), we KEEP these badges. They represent a
+# moment in time or an admin decision, not an ongoing condition.
+_NON_REVOCABLE_STRATEGIES = {
+    "first_n",           # Pioneer — "first 100 to pin location" is historical
+    "per_city_first",    # Founding Host — first event in a city is historical
+    "leaderboard",       # Local Legend — awarded annually, historical
+    "manual",            # OSS Contributor / Suggestion Box — admin choice
+    "year_range",        # Innopolis OG — graduation year is a lifetime fact
+}
+
+
+def revoke_ineligible(db: Session, alumni: Alumni) -> list[str]:
+    """Delete any of the alumnus's badges whose criteria no longer hold.
+
+    Only touches badges whose strategy is revocable (count-based, distinct-
+    count, profile completeness, badge count). Historical / lifetime badges
+    listed in `_NON_REVOCABLE_STRATEGIES` are preserved even if the raw
+    signal isn't there anymore.
+
+    Cascades: if revoking a badge drops the total count below Badge
+    Collector's threshold, Badge Collector is revoked too. Loop is bounded
+    at 3 rounds to prevent runaway.
+
+    Returns the list of revoked badge codes.
+    """
+    revoked: list[str] = []
+    for _round in range(3):
+        did_revoke = False
+        awarded = (
+            db.query(UserBadge, Badge)
+            .join(Badge, Badge.id == UserBadge.badge_id)
+            .filter(UserBadge.alumni_id == alumni.id)
+            .all()
+        )
+        for ub, b in awarded:
+            if b.strategy in _NON_REVOCABLE_STRATEGIES:
+                continue
+            try:
+                should_keep, _extra = _should_award(db, alumni, b)
+                if not should_keep:
+                    db.delete(ub)
+                    # Flush so subsequent checks in this round (e.g. Badge
+                    # Collector's count query) see the deletion.
+                    db.flush()
+                    revoked.append(b.code)
+                    did_revoke = True
+            except Exception as e:
+                logger.error("badge revoke check failed for %s: %s", b.code, e)
+        if did_revoke:
+            db.commit()
+        else:
+            break
+    return revoked
+
+
 def evaluate_for_user(
     db: Session, alumni: Alumni, trigger: str, context: dict | None = None
 ) -> list[UserBadge]:


### PR DESCRIPTION
## Summary
- When a participant leaves an event, re-evaluate their revocable badges and drop any whose criteria no longer hold (Networker, Cross-city commuter, Rainmaker, and cascaded Badge Collector).
- Preserve historical / lifetime badges via a `_NON_REVOCABLE_STRATEGIES` set: Pioneer (`first_n`), Founding Host (`per_city_first`), Local Legend (`leaderboard`), OSS Contributor / Suggestion Box (`manual`), Innopolis OG (`year_range`).
- Cascade is bounded at 3 rounds; the whole revocation pass is wrapped in a try/except so it never blocks the leave response.

## Why
Before this change, a user could earn Networker by attending 5 events, then leave 4 of them and still keep the badge — the criteria no longer held but the row lived on. Cross-city commuter and Rainmaker had the same issue.

## Test plan
- [x] Attend 5 events → Networker awarded → leave 1 → Networker gone; the locked card shows `4 / 5` again.
- [x] Attend an event in a different city → Cross-city commuter awarded → leave → Cross-city commuter gone.
- [x] Own an event that hit 20 attendees → Rainmaker awarded → a participant leaves, dropping attendance to 19 → Rainmaker gone for the owner (cascade).
- [x] Revoking a badge that drops the total badge count below Badge Collector's threshold also revokes Badge Collector.
- [x] Pioneer / Innopolis OG stay put even when unrelated participation changes.