### PR TITLE
feat(badges): Local Legend leaderboard + yearly cron [#6]

### DIFF
--- a/app/api/routes/admin/__init__.py
+++ b/app/api/routes/admin/__init__.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from app.api.routes.admin import (
     approve_event,
     badges_award,
+    badges_recompute_leaderboards,
     badges_revoke,
     ban,
     decline_event,
@@ -36,3 +37,4 @@ router.include_router(upload_allowed_emails.router)
 router.include_router(email_diagnostic.router)
 router.include_router(badges_award.router)
 router.include_router(badges_revoke.router)
+router.include_router(badges_recompute_leaderboards.router)

--- a/app/api/routes/admin/__init__.py
+++ b/app/api/routes/admin/__init__.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from app.api.routes.admin import (
     approve_event,
     badges_award,
+    badges_list,
     badges_recompute_leaderboards,
     badges_revoke,
     ban,
@@ -35,6 +36,7 @@ router.include_router(unverify_user.router)
 router.include_router(list_users.router)
 router.include_router(upload_allowed_emails.router)
 router.include_router(email_diagnostic.router)
+router.include_router(badges_list.router)
 router.include_router(badges_award.router)
 router.include_router(badges_revoke.router)
 router.include_router(badges_recompute_leaderboards.router)

--- a/app/api/routes/admin/badges_list.py
+++ b/app/api/routes/admin/badges_list.py
@@ -1,0 +1,133 @@
+"""Admin catalog + per-badge award listings.
+
+Powers the admin portal's Badges page:
+
+  GET /api/v1/admin/badges                     — catalog + earned_by counts
+  GET /api/v1/admin/badges/{code}/awards       — users holding the badge
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import get_current_user
+from app.models.badge import Badge, UserBadge
+from app.models.users import Admin, Alumni
+
+
+router = APIRouter()
+
+
+def _criteria_summary(badge: Badge) -> str:
+    """Human-readable one-liner describing the badge's award rule."""
+    params = badge.params or {}
+    strat = badge.strategy
+
+    if strat == "count_threshold":
+        metric = params.get("metric", "").replace("_", " ")
+        return f"Reach {params.get('threshold', 1)} {metric}".strip()
+    if strat == "distinct_count":
+        metric = params.get("metric", "").replace("_", " ")
+        return f"Reach {params.get('threshold', 1)} {metric}".strip()
+    if strat == "year_range":
+        lo, hi = params.get("min", "?"), params.get("max", "?")
+        return f"Graduation year in {lo}-{hi}"
+    if strat == "profile_completeness":
+        fields = params.get("fields", [])
+        return f"Fill all of: {', '.join(fields)}"
+    if strat == "badge_count":
+        return f"Earn {params.get('threshold', 10)} badges"
+    if strat == "first_n":
+        return f"Be among the first {params.get('n', 100)} to pin location"
+    if strat == "per_city_first":
+        return "Host the first event in a new city"
+    if strat == "leaderboard":
+        return "Highest yearly attendance in a city (auto-awarded)"
+    if strat == "manual":
+        return "Manually awarded by an admin"
+    return strat
+
+
+@router.get("/badges", status_code=status.HTTP_200_OK)
+def admin_list_badges(
+    db: Session = Depends(get_db),
+    current_user: Admin | Alumni = Depends(get_current_user),
+):
+    """Every badge in the catalog with its awarded-count and criteria line."""
+    if not isinstance(current_user, Admin):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin privileges required",
+        )
+
+    counts_by_badge_id: dict[str, int] = dict(
+        db.query(UserBadge.badge_id, func.count(UserBadge.id))
+        .group_by(UserBadge.badge_id)
+        .all()
+    )
+
+    catalog = db.query(Badge).order_by(Badge.tier.asc(), Badge.name.asc()).all()
+    return [
+        {
+            "code": b.code,
+            "name": b.name,
+            "description": b.description,
+            "tier": b.tier,
+            "icon_key": b.icon_key,
+            "strategy": b.strategy,
+            "criteria_summary": _criteria_summary(b),
+            "earned_by_count": counts_by_badge_id.get(b.id, 0),
+        }
+        for b in catalog
+    ]
+
+
+@router.get("/badges/{code}/awards", status_code=status.HTTP_200_OK)
+def admin_list_badge_awards(
+    code: str,
+    db: Session = Depends(get_db),
+    current_user: Admin | Alumni = Depends(get_current_user),
+):
+    """Users who hold `code`, one row per UserBadge instance.
+
+    Per-instance is important for Local Legend / Founding Host — the same
+    badge can be held multiple times with different `extra` metadata (one
+    per (city, year) for Local Legend, one per city for Founding Host).
+    """
+    if not isinstance(current_user, Admin):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin privileges required",
+        )
+
+    badge = db.query(Badge).filter(Badge.code == code).first()
+    if badge is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Badge not found"
+        )
+
+    rows = (
+        db.query(UserBadge, Alumni)
+        .join(Alumni, Alumni.id == UserBadge.alumni_id)
+        .filter(UserBadge.badge_id == badge.id)
+        .order_by(UserBadge.awarded_at.desc())
+        .all()
+    )
+
+    return {
+        "code": badge.code,
+        "name": badge.name,
+        "awards": [
+            {
+                "alumni_id": alumni.id,
+                "first_name": alumni.first_name,
+                "last_name": alumni.last_name,
+                "email": alumni.email,
+                "awarded_at": ub.awarded_at.isoformat() if ub.awarded_at else None,
+                "awarded_by": ub.awarded_by,
+                "extra": ub.extra or {},
+            }
+            for ub, alumni in rows
+        ],
+    }

--- a/app/api/routes/admin/badges_recompute_leaderboards.py
+++ b/app/api/routes/admin/badges_recompute_leaderboards.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import get_current_user
+from app.models.users import Admin, Alumni
+from app.services.badges import compute_local_legend_winners
+
+
+router = APIRouter()
+
+
+@router.post("/badges/recompute-leaderboards", status_code=status.HTTP_200_OK)
+def admin_recompute_leaderboards(
+    year: int | None = None,
+    db: Session = Depends(get_db),
+    current_user: Admin | Alumni = Depends(get_current_user),
+):
+    """Recompute Local Legend winners for a given year.
+
+    Defaults to the previous calendar year so admins can trigger the
+    same computation the cron would have run without passing a param.
+    Backfill mode: pass an explicit `year` to award winners for any
+    historical year. Idempotent — safe to re-run.
+    """
+    if not isinstance(current_user, Admin):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin privileges required",
+        )
+
+    target_year = year if year is not None else datetime.utcnow().year - 1
+    winners = compute_local_legend_winners(db, target_year)
+
+    return {
+        "year": target_year,
+        "awarded": len(winners),
+    }

--- a/app/services/badges.py
+++ b/app/services/badges.py
@@ -582,3 +582,82 @@ def manual_revoke(
         db.delete(r)
     db.commit()
     return badge
+
+
+# ─────────────────────────── leaderboard (Local Legend) ────────────────────
+
+
+def compute_local_legend_winners(
+    db: Session, year: int
+) -> list[UserBadge]:
+    """Compute Local Legend winners for the given year.
+
+    For each city (normalized `event.location` lowercased + trimmed)
+    that had approved events in the year, find the alumni with the
+    highest attendance count. Ties broken deterministically by the
+    earliest `event.datetime` among that alumni's attended events in
+    that city.
+
+    Idempotent: relies on the `(alumni_id, badge_id, extra)` unique
+    constraint to avoid double-awards on re-run.
+
+    Future improvement: introduce an FK from `events.city_id` to the
+    `cities` table so this is a clean SQL join instead of Python-side
+    grouping on a lower/trim of a free-text column.
+    """
+    badge = db.query(Badge).filter(Badge.code == "local_legend").first()
+    if badge is None:
+        logger.warning("compute_local_legend_winners: Local Legend badge not seeded")
+        return []
+
+    year_start = datetime(year, 1, 1)
+    year_end = datetime(year + 1, 1, 1)
+    events = (
+        db.query(Event)
+        .filter(
+            Event.approved.is_(True),
+            Event.datetime >= year_start,
+            Event.datetime < year_end,
+            Event.location.isnot(None),
+        )
+        .order_by(Event.datetime.asc())
+        .all()
+    )
+
+    # Group: city → alumni_id → (count, earliest_datetime).
+    per_city: dict[str, dict[str, tuple[int, datetime]]] = {}
+    for e in events:
+        city = (e.location or "").strip().lower()
+        if not city:
+            continue
+        for alumni_id in (e.participants_ids or []):
+            bucket = per_city.setdefault(city, {})
+            if alumni_id in bucket:
+                count, earliest = bucket[alumni_id]
+                bucket[alumni_id] = (count + 1, min(earliest, e.datetime))
+            else:
+                bucket[alumni_id] = (1, e.datetime)
+
+    winners: list[UserBadge] = []
+    for city, tally in per_city.items():
+        if not tally:
+            continue
+        # Highest count → earliest first-attendance → alumni_id, as a
+        # single min() over a tuple that inverts count so more is better.
+        winner_id, _ = min(
+            tally.items(),
+            key=lambda kv: (-kv[1][0], kv[1][1], kv[0]),
+        )
+
+        row = _award(
+            db,
+            winner_id,
+            badge,
+            extra={"city": city, "year": year},
+        )
+        if row is not None:
+            winners.append(row)
+
+    if winners:
+        db.commit()
+    return winners

--- a/cron/crontab
+++ b/cron/crontab
@@ -1,2 +1,5 @@
 # Event reminder cron job - runs every hour
 0 * * * * cd /app && python scripts/send_event_reminders.py >> /app/logs/reminders.log 2>&1
+
+# Local Legend leaderboard — annual, Jan 2 00:30 UTC (awards winners for previous year)
+30 0 2 1 * cd /app && python scripts/recompute_local_legend.py >> /app/logs/local_legend.log 2>&1

--- a/scripts/recompute_local_legend.py
+++ b/scripts/recompute_local_legend.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Compute Local Legend winners for a target year.
+
+By default runs for the previous calendar year (the cron use case).
+Pass `--year YYYY` for a backfill.
+
+Usage:
+    python scripts/recompute_local_legend.py
+    python scripts/recompute_local_legend.py --year 2024
+"""
+
+import argparse
+from datetime import datetime
+import logging
+import os
+import sys
+
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.services.badges import compute_local_legend_winners
+
+
+load_dotenv(override=True)
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger("local_legend_cron")
+
+
+def _session():
+    url = os.getenv("SQLALCHEMY_DATABASE_URL")
+    if not url:
+        raise RuntimeError("SQLALCHEMY_DATABASE_URL not set")
+    engine = create_engine(url)
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--year",
+        type=int,
+        default=None,
+        help="Calendar year to compute winners for (defaults to previous year)",
+    )
+    args = parser.parse_args()
+
+    target_year = (
+        args.year if args.year is not None else datetime.utcnow().year - 1
+    )
+    logger.info("Computing Local Legend winners for year %s", target_year)
+
+    db = _session()
+    try:
+        winners = compute_local_legend_winners(db, target_year)
+        logger.info(
+            "Local Legend %s complete: %d winners awarded", target_year, len(winners)
+        )
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_local_legend.py
+++ b/tests/test_local_legend.py
@@ -1,0 +1,243 @@
+"""Tests for compute_local_legend_winners — the yearly leaderboard.
+
+Awards one Local Legend per city (normalized `events.location`) per year,
+tie-broken deterministically by earliest attendance datetime then alumni id.
+Idempotent on re-run.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+import uuid
+
+import pytest
+from sqlalchemy import JSON
+
+from app.models.badge import Badge, UserBadge
+from app.models.email_verification import (
+    EmailVerification,  # noqa: F401 — needed for Alumni relationship resolution
+)
+from app.models.events import Event
+from app.models.users import Alumni
+from app.services import badges as service
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _patch_badge_columns_for_sqlite():
+    for col in Badge.__table__.columns:
+        if col.type.__class__.__name__ in ("JSONB", "ARRAY"):
+            col.type = JSON()
+    for col in UserBadge.__table__.columns:
+        if col.type.__class__.__name__ in ("JSONB",):
+            col.type = JSON()
+    return
+
+
+@pytest.fixture
+def db(db_session, engine):
+    Badge.__table__.create(bind=engine, checkfirst=True)
+    UserBadge.__table__.create(bind=engine, checkfirst=True)
+    yield db_session
+    db_session.expire_all()
+
+
+def _alumni(db, alumni_id: str | None = None) -> Alumni:
+    a = Alumni(
+        id=alumni_id or str(uuid.uuid4()),
+        email=f"{uuid.uuid4().hex[:8]}@innopolis.university",
+        hashed_password="x",
+        first_name="A",
+        last_name="B",
+        graduation_year="2018",
+        is_verified=True,
+        is_banned=False,
+    )
+    db.add(a)
+    db.flush()
+    return a
+
+
+def _event(
+    db,
+    owner_id: str,
+    location: str,
+    when: datetime,
+    participants: list[str],
+    approved: bool = True,
+) -> Event:
+    e = Event(
+        id=str(uuid.uuid4()),
+        owner_id=owner_id,
+        participants_ids=participants,
+        title="e",
+        description="",
+        location=location,
+        datetime=when,
+        cost=0.0,
+        is_online=False,
+        approved=approved,
+    )
+    db.add(e)
+    db.flush()
+    return e
+
+
+def _seed_badge(db) -> Badge:
+    b = Badge(
+        id=str(uuid.uuid4()),
+        code="local_legend",
+        name="Local Legend",
+        description="",
+        tier="gold",
+        icon_key="crown",
+        strategy="leaderboard",
+        params={},
+        trigger_metrics=[],
+    )
+    db.add(b)
+    db.flush()
+    return b
+
+
+class TestComputeLocalLegend:
+    def test_one_winner_per_city(self, db):
+        _seed_badge(db)
+        owner = _alumni(db)
+        alice = _alumni(db, "alice")
+        bob = _alumni(db, "bob")
+        carol = _alumni(db, "carol")
+
+        # Dubai: alice attends 3, bob 1 → alice wins.
+        for i in range(3):
+            _event(
+                db, owner.id, "Dubai", datetime(2025, 6, i + 1),
+                participants=[alice.id],
+            )
+        _event(
+            db, owner.id, "Dubai", datetime(2025, 7, 1), participants=[bob.id]
+        )
+        # Berlin: carol 2, alice 1 → carol wins.
+        for i in range(2):
+            _event(
+                db, owner.id, "Berlin", datetime(2025, 5, i + 1),
+                participants=[carol.id],
+            )
+        _event(
+            db, owner.id, "Berlin", datetime(2025, 5, 10), participants=[alice.id]
+        )
+        db.commit()
+
+        winners = service.compute_local_legend_winners(db, 2025)
+
+        assert len(winners) == 2
+        winner_by_city = {w.extra["city"]: w.alumni_id for w in winners}
+        assert winner_by_city == {"dubai": alice.id, "berlin": carol.id}
+
+    def test_tiebreak_earliest_attendance(self, db):
+        _seed_badge(db)
+        owner = _alumni(db)
+        alice = _alumni(db, "alice")
+        bob = _alumni(db, "bob")
+
+        # Both attend 2 events in Kazan → tie. Alice attended earlier (Jan 1),
+        # so she wins even though Bob's IDs might sort otherwise.
+        _event(db, owner.id, "Kazan", datetime(2025, 1, 1), participants=[alice.id])
+        _event(db, owner.id, "Kazan", datetime(2025, 3, 1), participants=[alice.id])
+        _event(db, owner.id, "Kazan", datetime(2025, 2, 1), participants=[bob.id])
+        _event(db, owner.id, "Kazan", datetime(2025, 4, 1), participants=[bob.id])
+        db.commit()
+
+        winners = service.compute_local_legend_winners(db, 2025)
+
+        assert len(winners) == 1
+        assert winners[0].alumni_id == alice.id
+
+    def test_no_events_in_year_awards_nothing(self, db):
+        _seed_badge(db)
+        winners = service.compute_local_legend_winners(db, 2025)
+        assert winners == []
+
+    def test_only_approved_events_counted(self, db):
+        _seed_badge(db)
+        owner = _alumni(db)
+        alice = _alumni(db, "alice")
+        bob = _alumni(db, "bob")
+
+        _event(
+            db, owner.id, "Prague", datetime(2025, 6, 1),
+            participants=[alice.id, bob.id], approved=True,
+        )
+        # Bob has 2 unapproved events — shouldn't count.
+        _event(
+            db, owner.id, "Prague", datetime(2025, 7, 1),
+            participants=[bob.id], approved=False,
+        )
+        _event(
+            db, owner.id, "Prague", datetime(2025, 8, 1),
+            participants=[bob.id], approved=False,
+        )
+        db.commit()
+
+        winners = service.compute_local_legend_winners(db, 2025)
+
+        # Tied at 1 each on approved events → earliest attendance wins.
+        # Alice and Bob both first attended on Jun 1 (same event). Fall
+        # through to alphabetical id tie-break → 'alice' < 'bob'.
+        assert len(winners) == 1
+        assert winners[0].alumni_id == alice.id
+
+    def test_events_from_other_year_not_counted(self, db):
+        _seed_badge(db)
+        owner = _alumni(db)
+        alice = _alumni(db, "alice")
+
+        _event(
+            db, owner.id, "Tokyo", datetime(2024, 12, 31),
+            participants=[alice.id],
+        )
+        _event(
+            db, owner.id, "Tokyo", datetime(2026, 1, 1), participants=[alice.id]
+        )
+        db.commit()
+
+        winners = service.compute_local_legend_winners(db, 2025)
+        assert winners == []
+
+    def test_idempotent_on_rerun(self, db):
+        _seed_badge(db)
+        owner = _alumni(db)
+        alice = _alumni(db, "alice")
+        alice_id = alice.id  # keep a plain-str copy across commits
+
+        _event(db, owner.id, "Rome", datetime(2025, 5, 1), participants=[alice_id])
+        db.commit()
+
+        first = service.compute_local_legend_winners(db, 2025)
+        second = service.compute_local_legend_winners(db, 2025)
+
+        # Both calls' semantics: first awards, second returns nothing
+        # because the (alumni_id, badge_id, extra) unique constraint
+        # rejects the duplicate insert.
+        assert len(first) == 1
+        assert second == []
+
+    def test_location_case_and_whitespace_normalized(self, db):
+        _seed_badge(db)
+        owner = _alumni(db)
+        alice = _alumni(db, "alice")
+
+        # "Cairo", " cairo ", "CAIRO" should all count for the same city.
+        _event(
+            db, owner.id, "Cairo", datetime(2025, 1, 1), participants=[alice.id]
+        )
+        _event(
+            db, owner.id, " cairo ", datetime(2025, 2, 1), participants=[alice.id]
+        )
+        _event(
+            db, owner.id, "CAIRO", datetime(2025, 3, 1), participants=[alice.id]
+        )
+        db.commit()
+
+        winners = service.compute_local_legend_winners(db, 2025)
+
+        assert len(winners) == 1
+        assert winners[0].extra == {"city": "cairo", "year": 2025}


### PR DESCRIPTION
## Summary
Computes one Local Legend per city per year. For every distinct normalized \`events.location\` string that saw approved events in the target year, awards the alumni with the highest attendance count in that city. Ties broken deterministically by earliest attendance datetime, then by \`alumni_id\`, so the result is stable across re-runs.

**New surface**
- \`compute_local_legend_winners(db, year)\` — pure service function, idempotent via the existing \`(alumni_id, badge_id, extra)\` unique constraint. City normalization: \`strip().lower()\` — a stand-in for a future FK to the \`cities\` table (noted in the code comment).
- \`POST /api/v1/admin/badges/recompute-leaderboards?year=YYYY\` — admin-only manual trigger. No \`year\` → defaults to previous calendar year (same as the cron). Useful for backfill and QA.
- \`scripts/recompute_local_legend.py\` — CLI wrapper for the cron container.
- \`cron/crontab\` — new annual entry: \`30 0 2 1 *\` (Jan 2 00:30 UTC).

## Base branch
Stacked on \`feat/manual-badge-awards\` ([#124](https://github.com/iu-alumni/iu-alumni-backend/pull/124)) so the admin router import graph stays clean. Merge order: #124 → this.

## Closes
Closes iu-alumni/iu-alumni-backend#113.

## Test plan
- [x] 7 new pytest cases: one winner per city, tie-break, empty year, only-approved filter, out-of-year, idempotent re-run, location case/whitespace normalization.
- [x] Full suite: 199 passed (excluding 3 pre-existing profile-route regressions on main).
- [ ] Smoke on staging: \`POST /api/v1/admin/badges/recompute-leaderboards?year=2024\` → sensible winner list.
- [ ] Container check: \`docker exec iu_alumni_cron crontab -l\` shows the new entry.