### PR TITLE
feat(projects): optional donation_link on projects

### DIFF
--- a/alembic/versions/7a3b1c9d5e2f_add_donation_link_to_projects.py
+++ b/alembic/versions/7a3b1c9d5e2f_add_donation_link_to_projects.py
@@ -1,8 +1,13 @@
 """Add donation_link column to projects
 
-Revision ID: e2f3a4b5c6d7
-Revises: d1e2f3a4b5c6
+Revision ID: 7a3b1c9d5e2f
+Revises: f3a4b5c6d7e8
 Create Date: 2026-07-16 13:00:00.000000
+
+Note: revision id renumbered from e2f3a4b5c6d7 (which was picked before
+the notifications-table migration landed on main and stole the same
+hex). down_revision bumped to the current main head to keep the chain
+linear rather than forcing an alembic merge.
 
 """
 from typing import Sequence, Union
@@ -11,8 +16,8 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision: str = "e2f3a4b5c6d7"
-down_revision: Union[str, None] = "d1e2f3a4b5c6"
+revision: str = "7a3b1c9d5e2f"
+down_revision: Union[str, None] = "f3a4b5c6d7e8"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/e2f3a4b5c6d7_add_donation_link_to_projects.py
+++ b/alembic/versions/e2f3a4b5c6d7_add_donation_link_to_projects.py
@@ -1,0 +1,28 @@
+"""Add donation_link column to projects
+
+Revision ID: e2f3a4b5c6d7
+Revises: d1e2f3a4b5c6
+Create Date: 2026-07-16 13:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "e2f3a4b5c6d7"
+down_revision: Union[str, None] = "d1e2f3a4b5c6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "projects",
+        sa.Column("donation_link", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("projects", "donation_link")

--- a/app/api/routes/projects/create_project.py
+++ b/app/api/routes/projects/create_project.py
@@ -39,6 +39,7 @@ async def create_project(
             detail="Description is required",
         )
 
+    donation_link = body.donation_link.strip() if body.donation_link else None
     project = Project(
         id=get_random_token(),
         owner_id=current_user.id,
@@ -46,6 +47,7 @@ async def create_project(
         title=body.title.strip(),
         description=body.description.strip(),
         cover=body.cover,
+        donation_link=donation_link or None,
         approved=None,
     )
     db.add(project)

--- a/app/api/routes/projects/update_project.py
+++ b/app/api/routes/projects/update_project.py
@@ -58,6 +58,13 @@ async def update_project(
         if new_cover != project.cover:
             project.cover = new_cover
             changed_content = True
+    if body.donation_link is not None:
+        # Empty string clears the link; anything else that differs from
+        # the stored value counts as an edit for the re-review gate.
+        new_link = body.donation_link.strip() or None
+        if new_link != project.donation_link:
+            project.donation_link = new_link
+            changed_content = True
 
     # If the owner touched any content, an approved project goes back to
     # pending so the change goes through admin review again.

--- a/app/models/projects.py
+++ b/app/models/projects.py
@@ -36,6 +36,10 @@ class Project(Base):
     title = Column(String, nullable=False)
     description = Column(String, nullable=False)
     cover = Column(String, nullable=True)
+    # Optional payment link (bank / Tinkoff / YooKassa / etc.). Free-text
+    # so we don't tie ourselves to a specific provider — the client just
+    # opens whatever URL the owner supplies.
+    donation_link = Column(String, nullable=True)
     approved = Column(Boolean, nullable=True, default=None, index=True)
     created_at = Column(
         DateTime, nullable=False, server_default=func.now()

--- a/app/schemas/project.py
+++ b/app/schemas/project.py
@@ -7,12 +7,14 @@ class CreateProjectRequest(BaseModel):
     title: str
     description: str
     cover: str | None = None
+    donation_link: str | None = None
 
 
 class UpdateProjectRequest(BaseModel):
     title: str | None = None
     description: str | None = None
     cover: str | None = None
+    donation_link: str | None = None
 
 
 class Project(BaseModel):
@@ -22,6 +24,7 @@ class Project(BaseModel):
     title: str
     description: str
     cover: str | None = None
+    donation_link: str | None = None
     approved: bool | None = None
     created_at: datetime
 
@@ -35,6 +38,7 @@ class ProjectListItem(BaseModel):
     title: str
     description: str
     cover: str | None = None
+    donation_link: str | None = None
     approved: bool | None = None
     created_at: datetime
 


### PR DESCRIPTION
## Summary
Adds an optional \`donation_link\` (nullable String) to the \`projects\` table so project owners can attach a payment URL (bank link / Tinkoff / YooKassa / anything they can link to). No in-app payment handling — mobile just opens the URL via \`url_launcher\`, admin portal renders it as a plain anchor.

Companion client changes:
- Mobile: [iu-alumni-mobile#148](https://github.com/iu-alumni/iu-alumni-mobile/pull/148) latest commit
- Admin portal: [iu-alumni-frontend#77](https://github.com/iu-alumni/iu-alumni-frontend/pull/77) latest commit

## Changes
- **Alembic \`e2f3a4b5c6d7\`** — additive: \`ALTER TABLE projects ADD COLUMN donation_link VARCHAR NULL;\`. No default, no backfill needed.
- **ORM** — new column on \`Project\`.
- **Pydantic schemas** — \`donation_link\` on \`CreateProjectRequest\`, \`UpdateProjectRequest\`, \`Project\` (response) and \`ProjectListItem\`.
- **\`create_project\`** — trims + normalizes empty-string to NULL on insert.
- **\`update_project\`** — treats the field like other content fields for the re-review gate: touching it on an approved project resets \`approved\` to NULL. Empty string clears the stored link.

## Test plan
- [x] Migration applies against the dev DB — head is now \`e2f3a4b5c6d7\`.
- [x] \`pytest tests/test_projects.py\` — 28 passed, 1 skipped. Existing behaviour untouched (field is purely additive).
- [x] Ruff clean on all changed files.
- [ ] Manual smoke: POST /projects/ with donation_link, then PUT with "" to clear, admin approve → mobile shows Donate button that opens the link.

## FR alignment
Partial coverage of FR24-b (link-based payment processing) — the "link" half of it. Real payment integration + reconciliation is still deferred; this just gives owners a place to put the URL and gives contributors a way to reach it.

---
Closes #149
