### PR TITLE
Seed city reference data on startup and add nearby-event notifications

### DIFF
--- a/alembic/versions/e2f3a4b5c6d7_add_notifications_table.py
+++ b/alembic/versions/e2f3a4b5c6d7_add_notifications_table.py
@@ -1,0 +1,59 @@
+"""Add notifications table
+
+Revision ID: e2f3a4b5c6d7
+Revises: d1e2f3a4b5c6
+Create Date: 2026-07-17 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e2f3a4b5c6d7"
+down_revision: Union[str, None] = "d1e2f3a4b5c6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notifications",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("alumni_id", sa.String(), nullable=False),
+        sa.Column("event_id", sa.String(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("read_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["alumni_id"], ["alumni.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["event_id"], ["events.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "alumni_id", "event_id", name="uq_notifications_alumni_event"
+        ),
+    )
+    op.create_index(
+        "ix_notifications_alumni_id", "notifications", ["alumni_id"], unique=False
+    )
+    op.create_index(
+        "ix_notifications_event_id", "notifications", ["event_id"], unique=False
+    )
+    op.create_index(
+        "ix_notifications_alumni_read",
+        "notifications",
+        ["alumni_id", "read_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_notifications_alumni_read", table_name="notifications")
+    op.drop_index("ix_notifications_event_id", table_name="notifications")
+    op.drop_index("ix_notifications_alumni_id", table_name="notifications")
+    op.drop_table("notifications")

--- a/alembic/versions/f3a4b5c6d7e8_replace_notifications_table_with_cursor.py
+++ b/alembic/versions/f3a4b5c6d7e8_replace_notifications_table_with_cursor.py
@@ -1,0 +1,70 @@
+"""Replace notifications table with a per-user read cursor
+
+Notification matches are now computed live from events + the user's
+profile city instead of being materialized as one row per (user, event) —
+see app/services/notifications.py. All that's needed to track read/unread
+state is a single timestamp per user.
+
+Revision ID: f3a4b5c6d7e8
+Revises: e2f3a4b5c6d7
+Create Date: 2026-07-18 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f3a4b5c6d7e8"
+down_revision: Union[str, None] = "e2f3a4b5c6d7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "alumni", sa.Column("notifications_seen_at", sa.DateTime(), nullable=True)
+    )
+
+    op.drop_index("ix_notifications_alumni_read", table_name="notifications")
+    op.drop_index("ix_notifications_event_id", table_name="notifications")
+    op.drop_index("ix_notifications_alumni_id", table_name="notifications")
+    op.drop_table("notifications")
+
+
+def downgrade() -> None:
+    op.create_table(
+        "notifications",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("alumni_id", sa.String(), nullable=False),
+        sa.Column("event_id", sa.String(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("read_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["alumni_id"], ["alumni.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["event_id"], ["events.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "alumni_id", "event_id", name="uq_notifications_alumni_event"
+        ),
+    )
+    op.create_index(
+        "ix_notifications_alumni_id", "notifications", ["alumni_id"], unique=False
+    )
+    op.create_index(
+        "ix_notifications_event_id", "notifications", ["event_id"], unique=False
+    )
+    op.create_index(
+        "ix_notifications_alumni_read",
+        "notifications",
+        ["alumni_id", "read_at"],
+        unique=False,
+    )
+
+    op.drop_column("alumni", "notifications_seen_at")

--- a/app/api/routes/notifications/__init__.py
+++ b/app/api/routes/notifications/__init__.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+from . import list_notifications, unread_count
+
+
+router = APIRouter()
+router.include_router(list_notifications.router)
+router.include_router(unread_count.router)

--- a/app/api/routes/notifications/list_notifications.py
+++ b/app/api/routes/notifications/list_notifications.py
@@ -1,0 +1,52 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import get_current_user
+from app.models.users import Admin, Alumni
+from app.schemas.notification import NotificationItem
+from app.schemas.pagination import Paginated
+from app.services.notifications import find_nearby_upcoming_events, is_read, mark_seen
+
+
+router = APIRouter()
+
+# Bounded by design — the ~24h-wide 7-day window practically never holds
+# more than a handful of events — so this is a safety cap, not real paging.
+MAX_ITEMS = 200
+
+
+@router.get("/", response_model=Paginated[NotificationItem])
+def list_notifications(
+    db: Session = Depends(get_db),
+    current_user: Alumni | Admin = Depends(get_current_user),
+):
+    """Lists events matching the current user right now (upcoming, near them).
+
+    No real pagination — next_cursor is always null; the envelope is kept
+    for API stability.
+
+    Viewing this list marks every currently-matching event as read for this
+    user (advances the read cursor) — an event is unread only the first
+    time it's viewed after entering the ~7-day window.
+    """
+    if not isinstance(current_user, Alumni):
+        return Paginated(items=[], next_cursor=None)
+
+    events = find_nearby_upcoming_events(db, current_user)[:MAX_ITEMS]
+
+    items = [
+        NotificationItem(
+            id=e.id,
+            event_id=e.id,
+            title=e.title,
+            location=e.location,
+            datetime=e.datetime,
+            read=is_read(current_user, e),
+        )
+        for e in events
+    ]
+
+    mark_seen(db, current_user)
+
+    return Paginated(items=items, next_cursor=None)

--- a/app/api/routes/notifications/unread_count.py
+++ b/app/api/routes/notifications/unread_count.py
@@ -16,8 +16,11 @@ def get_unread_count(
     db: Session = Depends(get_db),
     current_user: Alumni | Admin = Depends(get_current_user),
 ):
-    """Count of currently-matching events not yet seen. Does not mark read —
-    used to drive the bell icon's badge without opening the list."""
+    """Count of currently-matching events not yet seen.
+
+    Does not mark read — used to drive the bell icon's badge without opening
+    the list.
+    """
     if not isinstance(current_user, Alumni):
         return UnreadCountResponse(count=0)
 

--- a/app/api/routes/notifications/unread_count.py
+++ b/app/api/routes/notifications/unread_count.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import get_current_user
+from app.models.users import Admin, Alumni
+from app.schemas.notification import UnreadCountResponse
+from app.services.notifications import find_nearby_upcoming_events, is_read
+
+
+router = APIRouter()
+
+
+@router.get("/unread-count", response_model=UnreadCountResponse)
+def get_unread_count(
+    db: Session = Depends(get_db),
+    current_user: Alumni | Admin = Depends(get_current_user),
+):
+    """Count of currently-matching events not yet seen. Does not mark read —
+    used to drive the bell icon's badge without opening the list."""
+    if not isinstance(current_user, Alumni):
+        return UnreadCountResponse(count=0)
+
+    events = find_nearby_upcoming_events(db, current_user)
+    count = sum(1 for e in events if not is_read(current_user, e))
+    return UnreadCountResponse(count=count)

--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from app.api.routes.authentication import router as auth_router
 from app.api.routes.badges import router as badges_router
 from app.api.routes.cities import router as cities_router
 from app.api.routes.events import router as events_router
+from app.api.routes.notifications import router as notifications_router
 from app.api.routes.profile import router as profile_router
 from app.api.routes.projects import router as projects_router
 from app.api.routes.telegram import router as telegram_router
@@ -21,6 +22,7 @@ from app.core.logging import app_logger, setup_logging
 from app.core.security import get_password_hash, get_random_token
 from app.models.users import Admin
 from app.services.telegram_polling import start_polling
+from scripts.seed_cities import seed_cities
 
 
 # Initialize logging
@@ -44,6 +46,18 @@ async def lifespan(app: FastAPI):
             app_logger.info("Initial admin user created")
         else:
             app_logger.debug("Admin user already exists")
+    finally:
+        db.close()
+
+    # Startup: seed reference city data if missing (needed for location
+    # search/autocomplete — /cities/search and /cities/coordinates).
+    db = SessionLocal()
+    try:
+        inserted = seed_cities(db)
+        if inserted:
+            app_logger.info(f"Seeded {inserted} new cities")
+        else:
+            app_logger.debug("Cities table already seeded")
     finally:
         db.close()
 
@@ -119,6 +133,7 @@ api_v1.include_router(admin_router, prefix="/admin", tags=["Admin"])
 api_v1.include_router(cities_router, prefix="/cities", tags=["Cities"])
 api_v1.include_router(badges_router, prefix="/badges", tags=["Badges"])
 api_v1.include_router(projects_router, prefix="/projects", tags=["Projects"])
+api_v1.include_router(notifications_router, prefix="/notifications", tags=["Notifications"])
 app.include_router(api_v1)
 app.include_router(telegram_router, tags=["Telegram"])
 

--- a/app/models/users.py
+++ b/app/models/users.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, String
+from sqlalchemy import Boolean, Column, DateTime, String
 from sqlalchemy.orm import relationship
 
 from app.core.database import Base
@@ -21,6 +21,10 @@ class Alumni(Base):
     avatar = Column(String)
     is_verified = Column(Boolean, default=False, index=True)
     is_banned = Column(Boolean, default=False, index=True)
+    # Cursor for the notifications panel: an event is "unread" until this
+    # is >= the moment the event entered the ~7-day notice window. See
+    # app/services/notifications.py.
+    notifications_seen_at = Column(DateTime, nullable=True)
 
     # Relationship
     email_verification = relationship(

--- a/app/schemas/notification.py
+++ b/app/schemas/notification.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class NotificationItem(BaseModel):
+    id: str
+    event_id: str
+    title: str
+    location: str
+    datetime: datetime
+    read: bool
+
+
+class UnreadCountResponse(BaseModel):
+    count: int

--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -78,8 +78,9 @@ def _window_entry_time(event: Event) -> datetime:
 def find_nearby_upcoming_events(
     db: Session, alumni: Alumni, now: datetime | None = None
 ) -> list[Event]:
-    """Approved events within ~7 days that are near `alumni`, most
-    recently-relevant first. Includes events that have already happened —
+    """Approved events near `alumni`, most recently-relevant first.
+
+    Covers a ~7 day window. Includes events that have already happened —
     a match doesn't disappear just because time passed or the event
     occurred; see the module docstring.
 
@@ -110,8 +111,10 @@ def find_nearby_upcoming_events(
 
 
 def is_read(alumni: Alumni, event: Event) -> bool:
-    """Whether `alumni` has viewed the notifications list since this event
-    entered the ~7-day window."""
+    """Whether `alumni` has viewed the list since this event became relevant.
+
+    "Relevant" means the point the event entered the ~7-day window.
+    """
     seen_at = alumni.notifications_seen_at
     return seen_at is not None and seen_at >= _window_entry_time(event)
 

--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -1,0 +1,122 @@
+"""Finds "upcoming event near you" matches for a user, computed live.
+
+An in-person event is "near" a user if it happens in the same city as the
+user's profile location, with Innopolis and Kazan treated as one city
+(alumni in one routinely attend events in the other, and they're a short
+commute apart). Online events are near everyone, regardless of location.
+
+Unlike a materialized per-(user, event) notification table, read/unread
+state here is tracked with a single per-user cursor
+(Alumni.notifications_seen_at). An event counts as "unread" until the user
+has viewed the notifications list at least once *after* the event entered
+the ~7-day window — computed purely from the event's own datetime, so no
+extra table or scheduled job is needed.
+
+This is a persistent history, not a transient popup: once an event enters
+the window (becomes <= 7 days + ENTRY_BUFFER away), it stays part of the
+result forever — including after the event has actually happened. There's
+no time-based upper cutoff that removes old matches; the response is
+bounded only by MAX_ITEMS in the list endpoint. This does mean the
+underlying query scans every approved event that has ever entered the
+window, growing over the app's lifetime — acceptable at this data scale,
+but worth knowing if event volume grows much larger.
+
+ENTRY_BUFFER exists only so an event's first appearance isn't sensitive to
+time-of-day: without it, an event scheduled for exactly "7 days and a few
+hours from now" wouldn't show up until real time closed that few-hour gap,
+even though it's clearly "about a week away." It only affects *when an
+event first appears* — it has no bearing on whether older matches keep
+showing, which they always do regardless of this buffer.
+
+Trade-off: because "entered the window" is derived from event.datetime
+rather than a real creation/approval timestamp, an event approved very
+late (already <= 7 days away) could show as already-read if the user
+happened to view the list recently for an unrelated reason. This is rare
+in practice — events are normally approved well before the 7-day mark —
+and is the accepted cost of not needing a table or background job.
+
+Public entry points:
+    find_nearby_upcoming_events(db, alumni) -> list[Event]
+    is_read(alumni, event) -> bool
+    mark_seen(db, alumni) -> None
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from app.models.events import Event
+from app.models.users import Alumni
+
+
+# Cities treated as interchangeable for "near me" matching.
+_CITY_ALIASES: dict[str, str] = {
+    "kazan": "innopolis",
+}
+
+NOTICE_LEAD_TIME = timedelta(days=7)
+ENTRY_BUFFER = timedelta(hours=12)
+
+
+def _city_bucket(location: str | None) -> str | None:
+    """Extract and normalize the city part of a "Country, City" string."""
+    if not location:
+        return None
+    parts = [p.strip() for p in location.split(",") if p.strip()]
+    if not parts:
+        return None
+    city = parts[-1].lower()
+    return _CITY_ALIASES.get(city, city)
+
+
+def _window_entry_time(event: Event) -> datetime:
+    """The moment this event started being "upcoming" (~7 days out)."""
+    return event.datetime - NOTICE_LEAD_TIME - ENTRY_BUFFER
+
+
+def find_nearby_upcoming_events(
+    db: Session, alumni: Alumni, now: datetime | None = None
+) -> list[Event]:
+    """Approved events within ~7 days that are near `alumni`, most
+    recently-relevant first. Includes events that have already happened —
+    a match doesn't disappear just because time passed or the event
+    occurred; see the module docstring.
+
+    Excludes the event's own owner/participants (they already know about
+    it). Online events match regardless of the alumnus's profile city;
+    in-person events only match alumni in the same city.
+    """
+    now = now or datetime.utcnow()
+
+    events = (
+        db.query(Event)
+        .filter(
+            Event.approved == True,
+            Event.datetime <= now + NOTICE_LEAD_TIME + ENTRY_BUFFER,
+        )
+        .order_by(Event.datetime.desc())
+        .all()
+    )
+
+    my_bucket = _city_bucket(alumni.location)
+    matches = []
+    for event in events:
+        if alumni.id == event.owner_id or alumni.id in (event.participants_ids or []):
+            continue
+        if event.is_online or (my_bucket and _city_bucket(event.location) == my_bucket):
+            matches.append(event)
+    return matches
+
+
+def is_read(alumni: Alumni, event: Event) -> bool:
+    """Whether `alumni` has viewed the notifications list since this event
+    entered the ~7-day window."""
+    seen_at = alumni.notifications_seen_at
+    return seen_at is not None and seen_at >= _window_entry_time(event)
+
+
+def mark_seen(db: Session, alumni: Alumni, now: datetime | None = None) -> None:
+    """Advances the read cursor — call after listing notifications."""
+    alumni.notifications_seen_at = now or datetime.utcnow()
+    db.commit()

--- a/scripts/seed_cities.py
+++ b/scripts/seed_cities.py
@@ -1,0 +1,93 @@
+"""Seed the `cities` table with reference city/country/lat/lng data.
+
+The table has an Alembic migration that creates it, but nothing populates
+it — `/cities/search` and `/cities/coordinates` return nothing until this
+runs. Source data: a world-cities dataset bundled at scripts/data/worldcities.csv
+(plus a couple of entries the dataset is missing but the platform needs).
+
+Idempotent: safe to re-run. Only inserts (city, country) pairs not already
+present in the table.
+
+Run with:
+    docker exec iu_alumni_backend python -m scripts.seed_cities
+"""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from app.core.database import SessionLocal
+from app.models.cities import City
+
+
+CSV_PATH = Path(__file__).parent / "data" / "worldcities.csv"
+
+# (city, country, lat, lng) — added regardless of whether the CSV has them.
+EXTRA_CITIES = [
+    ("Innopolis", "Russia", 55.752117, 48.744552),
+]
+
+
+def _load_rows(csv_path: Path) -> list[tuple[str, str, float, float]]:
+    """Read csv_path into deduped (city, country, lat, lng) tuples.
+
+    Dedupes on (city, country) since that's the table's primary key —
+    keeps the first occurrence found.
+    """
+    seen: set[tuple[str, str]] = set()
+    rows: list[tuple[str, str, float, float]] = []
+
+    with csv_path.open(encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            key = (row["city"], row["country"])
+            if key in seen:
+                continue
+            try:
+                lat, lng = float(row["lat"]), float(row["lng"])
+            except (KeyError, ValueError):
+                continue
+            seen.add(key)
+            rows.append((row["city"], row["country"], lat, lng))
+
+    for city, country, lat, lng in EXTRA_CITIES:
+        if (city, country) not in seen:
+            seen.add((city, country))
+            rows.append((city, country, lat, lng))
+
+    return rows
+
+
+def seed_cities(db, csv_path: Path = CSV_PATH) -> int:
+    """Insert any (city, country) pairs from csv_path missing from the table.
+
+    Returns the number of rows inserted.
+    """
+    rows = _load_rows(csv_path)
+
+    existing = {(city, country) for city, country in db.query(City.city, City.country)}
+    new_rows = [
+        {"city": city, "country": country, "lat": lat, "lng": lng}
+        for city, country, lat, lng in rows
+        if (city, country) not in existing
+    ]
+
+    if new_rows:
+        db.execute(City.__table__.insert(), new_rows)
+        db.commit()
+
+    return len(new_rows)
+
+
+def main() -> None:
+    db = SessionLocal()
+    try:
+        inserted = seed_cities(db)
+        total = db.query(City).count()
+        print(f"inserted {inserted} new cities ({total} total in table)")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,7 @@ def client(db_session):
     from app.api.routes.authentication import router as auth_router
     from app.api.routes.cities import router as cities_router
     from app.api.routes.events import router as events_router
+    from app.api.routes.notifications import router as notifications_router
     from app.api.routes.profile import router as profile_router
     from app.api.routes.projects import router as projects_router
     from app.api.routes.telegram import router as telegram_router
@@ -130,6 +131,9 @@ def client(db_session):
     api_v1.include_router(admin_router, prefix="/admin", tags=["Admin"])
     api_v1.include_router(cities_router, prefix="/cities", tags=["Cities"])
     api_v1.include_router(projects_router, prefix="/projects", tags=["Projects"])
+    api_v1.include_router(
+        notifications_router, prefix="/notifications", tags=["Notifications"]
+    )
     app.include_router(api_v1)
     app.include_router(telegram_router, tags=["Telegram"])
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,239 @@
+from datetime import datetime, timedelta
+
+from app.models.email_verification import (
+    EmailVerification,  # noqa: F401 — registers relationship
+)
+from app.models.events import Event
+from app.models.users import Alumni
+from app.services.notifications import (
+    ENTRY_BUFFER,
+    NOTICE_LEAD_TIME,
+    find_nearby_upcoming_events,
+    is_read,
+    mark_seen,
+)
+
+
+def _alumni(id_, location, **kw):
+    return Alumni(
+        id=id_,
+        email=f"{id_}@innopolis.university",
+        first_name="Test",
+        last_name="User",
+        graduation_year="2025",
+        location=location,
+        is_verified=True,
+        is_banned=False,
+        **kw,
+    )
+
+
+def _event(id_, owner_id, location, days_from_now, **kw):
+    return Event(
+        id=id_,
+        owner_id=owner_id,
+        participants_ids=kw.pop("participants_ids", [owner_id]),
+        title=f"Event {id_}",
+        description="desc",
+        location=location,
+        datetime=datetime.utcnow() + timedelta(days=days_from_now),
+        cost=0.0,
+        is_online=kw.pop("is_online", False),
+        approved=kw.pop("approved", True),
+    )
+
+
+def test_matches_event_in_same_city_within_window(db_session):
+    owner = _alumni("owner", "Russia, Innopolis")
+    nearby = _alumni("nearby", "Russia, Innopolis")
+    db_session.add_all([owner, nearby])
+    db_session.add(_event("evt1", "owner", "Russia, Innopolis", days_from_now=7))
+    db_session.commit()
+
+    matches = find_nearby_upcoming_events(db_session, nearby)
+
+    assert [e.id for e in matches] == ["evt1"]
+
+
+def test_innopolis_and_kazan_treated_as_same_city(db_session):
+    owner = _alumni("owner", "Russia, Innopolis")
+    kazan_user = _alumni("kazan_user", "Russia, Kazan")
+    db_session.add_all([owner, kazan_user])
+    db_session.add(_event("evt1", "owner", "Russia, Innopolis", days_from_now=7))
+    db_session.commit()
+
+    matches = find_nearby_upcoming_events(db_session, kazan_user)
+
+    assert [e.id for e in matches] == ["evt1"]
+
+
+def test_different_city_does_not_match(db_session):
+    owner = _alumni("owner", "Russia, Innopolis")
+    far_away = _alumni("far_away", "Germany, Berlin")
+    db_session.add_all([owner, far_away])
+    db_session.add(_event("evt1", "owner", "Russia, Innopolis", days_from_now=7))
+    db_session.commit()
+
+    matches = find_nearby_upcoming_events(db_session, far_away)
+
+    assert matches == []
+
+
+def test_excludes_owner_and_participants(db_session):
+    owner = _alumni("owner", "Russia, Innopolis")
+    participant = _alumni("participant", "Russia, Innopolis")
+    db_session.add_all([owner, participant])
+    db_session.add(
+        _event(
+            "evt1",
+            "owner",
+            "Russia, Innopolis",
+            days_from_now=7,
+            participants_ids=["owner", "participant"],
+        )
+    )
+    db_session.commit()
+
+    assert find_nearby_upcoming_events(db_session, owner) == []
+    assert find_nearby_upcoming_events(db_session, participant) == []
+
+
+def test_online_events_match_regardless_of_city(db_session):
+    owner = _alumni("owner", "Russia, Innopolis")
+    far_away = _alumni("far_away", "Germany, Berlin")
+    no_location = _alumni("no_location", None)
+    db_session.add_all([owner, far_away, no_location])
+    db_session.add(
+        _event("evt1", "owner", "Russia, Innopolis", days_from_now=7, is_online=True)
+    )
+    db_session.commit()
+
+    assert [e.id for e in find_nearby_upcoming_events(db_session, far_away)] == ["evt1"]
+    assert [e.id for e in find_nearby_upcoming_events(db_session, no_location)] == [
+        "evt1"
+    ]
+
+
+def test_online_events_still_exclude_owner_and_participants(db_session):
+    owner = _alumni("owner", "Russia, Innopolis")
+    participant = _alumni("participant", "Germany, Berlin")
+    db_session.add_all([owner, participant])
+    db_session.add(
+        _event(
+            "evt1",
+            "owner",
+            "Russia, Innopolis",
+            days_from_now=7,
+            is_online=True,
+            participants_ids=["owner", "participant"],
+        )
+    )
+    db_session.commit()
+
+    assert find_nearby_upcoming_events(db_session, owner) == []
+    assert find_nearby_upcoming_events(db_session, participant) == []
+
+
+def test_events_within_a_week_match_however_soon(db_session):
+    owner = _alumni("owner", "Russia, Innopolis")
+    nearby = _alumni("nearby", "Russia, Innopolis")
+    db_session.add_all([owner, nearby])
+    db_session.add(_event("evt_soon", "owner", "Russia, Innopolis", days_from_now=1))
+    db_session.commit()
+
+    assert [e.id for e in find_nearby_upcoming_events(db_session, nearby)] == [
+        "evt_soon"
+    ]
+
+
+def test_excludes_events_more_than_a_week_out(db_session):
+    owner = _alumni("owner", "Russia, Innopolis")
+    nearby = _alumni("nearby", "Russia, Innopolis")
+    db_session.add_all([owner, nearby])
+    db_session.add(_event("evt_far", "owner", "Russia, Innopolis", days_from_now=30))
+    db_session.commit()
+
+    assert find_nearby_upcoming_events(db_session, nearby) == []
+
+
+def test_matches_event_just_past_the_exact_seven_day_mark(db_session):
+    """Regression: an event 7 days + a few hours out is still "about a
+    week away" and must match — the ENTRY_BUFFER exists exactly so a
+    match's first appearance doesn't depend on time-of-day."""
+    owner = _alumni("owner", "Russia, Innopolis")
+    nearby = _alumni("nearby", "Russia, Innopolis")
+    db_session.add_all([owner, nearby])
+    db_session.add(_event("evt1", "owner", "Russia, Innopolis", days_from_now=7.1))
+    db_session.commit()
+
+    assert [e.id for e in find_nearby_upcoming_events(db_session, nearby)] == ["evt1"]
+
+
+def test_includes_events_that_already_happened(db_session):
+    """Once an event enters the window it stays part of the user's
+    notification history — it doesn't disappear just because it occurred
+    or because real time has since moved past it."""
+    owner = _alumni("owner", "Russia, Innopolis")
+    nearby = _alumni("nearby", "Russia, Innopolis")
+    db_session.add_all([owner, nearby])
+    db_session.add(_event("evt_past", "owner", "Russia, Innopolis", days_from_now=-2))
+    db_session.commit()
+
+    assert [e.id for e in find_nearby_upcoming_events(db_session, nearby)] == [
+        "evt_past"
+    ]
+
+
+def test_excludes_unapproved_events(db_session):
+    owner = _alumni("owner", "Russia, Innopolis")
+    nearby = _alumni("nearby", "Russia, Innopolis")
+    db_session.add_all([owner, nearby])
+    db_session.add(
+        _event("evt1", "owner", "Russia, Innopolis", days_from_now=7, approved=False)
+    )
+    db_session.commit()
+
+    assert find_nearby_upcoming_events(db_session, nearby) == []
+
+
+def test_alumni_without_location_never_matched_for_in_person_events(db_session):
+    owner = _alumni("owner", "Russia, Innopolis")
+    no_location = _alumni("no_location", None)
+    db_session.add_all([owner, no_location])
+    db_session.add(_event("evt1", "owner", "Russia, Innopolis", days_from_now=7))
+    db_session.commit()
+
+    assert find_nearby_upcoming_events(db_session, no_location) == []
+
+
+def test_unread_until_seen_after_event_enters_window(db_session):
+    owner = _alumni("owner", "Russia, Innopolis")
+    nearby = _alumni("nearby", "Russia, Innopolis")
+    db_session.add_all([owner, nearby])
+    event = _event("evt1", "owner", "Russia, Innopolis", days_from_now=7)
+    db_session.add(event)
+    db_session.commit()
+
+    # Never viewed -> unread.
+    assert is_read(nearby, event) is False
+
+    # Viewed *before* the event entered the window -> still unread.
+    nearby.notifications_seen_at = (
+        event.datetime - NOTICE_LEAD_TIME - ENTRY_BUFFER - timedelta(minutes=1)
+    )
+    assert is_read(nearby, event) is False
+
+    # Viewed *after* the event entered the window -> read.
+    mark_seen(db_session, nearby)
+    assert is_read(nearby, event) is True
+
+
+def test_mark_seen_persists(db_session):
+    user = _alumni("user1", "Russia, Innopolis")
+    db_session.add(user)
+    db_session.commit()
+    assert user.notifications_seen_at is None
+
+    mark_seen(db_session, user)
+
+    assert user.notifications_seen_at is not None

--- a/tests/test_notifications_routes.py
+++ b/tests/test_notifications_routes.py
@@ -1,0 +1,168 @@
+from datetime import datetime, timedelta
+
+from app.api.routes.notifications.list_notifications import list_notifications
+from app.api.routes.notifications.unread_count import get_unread_count
+from app.models.email_verification import (
+    EmailVerification,  # noqa: F401 — registers relationship
+)
+from app.models.events import Event
+from app.models.users import Alumni
+
+
+def _seed_matching_event(db_session):
+    owner = Alumni(
+        id="owner",
+        email="owner@innopolis.university",
+        first_name="Owner",
+        last_name="User",
+        graduation_year="2020",
+        location="Russia, Innopolis",
+        is_verified=True,
+        is_banned=False,
+    )
+    user = Alumni(
+        id="user1",
+        email="user1@innopolis.university",
+        first_name="Test",
+        last_name="User",
+        graduation_year="2025",
+        location="Russia, Innopolis",
+        is_verified=True,
+        is_banned=False,
+    )
+    event = Event(
+        id="evt1",
+        owner_id="owner",
+        participants_ids=["owner"],
+        title="Reunion",
+        description="desc",
+        location="Russia, Innopolis",
+        datetime=datetime.utcnow() + timedelta(days=7),
+        cost=0.0,
+        is_online=False,
+        approved=True,
+    )
+    db_session.add_all([owner, user, event])
+    db_session.commit()
+    return user
+
+
+def test_unread_count_reflects_a_matching_event(db_session):
+    user = _seed_matching_event(db_session)
+
+    result = get_unread_count(db=db_session, current_user=user)
+
+    assert result.count == 1
+
+
+def test_unread_count_does_not_mark_as_read(db_session):
+    user = _seed_matching_event(db_session)
+
+    get_unread_count(db=db_session, current_user=user)
+
+    assert user.notifications_seen_at is None
+
+
+def test_list_notifications_shows_unread_on_first_view(db_session):
+    user = _seed_matching_event(db_session)
+
+    result = list_notifications(db=db_session, current_user=user)
+
+    assert len(result.items) == 1
+    item = result.items[0]
+    assert item.read is False
+    assert item.title == "Reunion"
+    assert item.location == "Russia, Innopolis"
+
+
+def test_list_notifications_marks_seen_as_a_side_effect(db_session):
+    user = _seed_matching_event(db_session)
+
+    list_notifications(db=db_session, current_user=user)
+
+    assert user.notifications_seen_at is not None
+
+
+def test_second_view_shows_notification_as_already_read(db_session):
+    user = _seed_matching_event(db_session)
+
+    list_notifications(db=db_session, current_user=user)
+    second_result = list_notifications(db=db_session, current_user=user)
+
+    assert second_result.items[0].read is True
+
+
+def test_unread_count_drops_to_zero_after_viewing_list(db_session):
+    user = _seed_matching_event(db_session)
+
+    list_notifications(db=db_session, current_user=user)
+    result = get_unread_count(db=db_session, current_user=user)
+
+    assert result.count == 0
+
+
+def test_event_entering_window_after_last_view_shows_as_unread(db_session):
+    """A currently-matching event's "entered the window" moment
+    (datetime - 7 days) is fixed by its own datetime. So whether it's read
+    depends on whether the user's cursor falls before or after that fixed
+    point — this pins both sides of that comparison directly, rather than
+    relying on real time passing between two calls (which wouldn't move
+    either event's fixed "entered the window" moment)."""
+    owner = Alumni(
+        id="owner",
+        email="owner@innopolis.university",
+        first_name="Owner",
+        last_name="User",
+        graduation_year="2020",
+        location="Russia, Innopolis",
+        is_verified=True,
+        is_banned=False,
+    )
+    user = Alumni(
+        id="user1",
+        email="user1@innopolis.university",
+        first_name="Test",
+        last_name="User",
+        graduation_year="2025",
+        location="Russia, Innopolis",
+        is_verified=True,
+        is_banned=False,
+    )
+    db_session.add_all([owner, user])
+
+    now = datetime.utcnow()
+    # window_entry_time = datetime - 7d - 12h (NOTICE_LEAD_TIME + ENTRY_BUFFER), so:
+    already_seen = Event(
+        id="evt_seen",
+        owner_id="owner",
+        participants_ids=["owner"],
+        title="Already Seen",
+        description="desc",
+        location="Russia, Innopolis",
+        datetime=now + timedelta(days=7, hours=-12),  # enters window at now-24h
+        cost=0.0,
+        is_online=False,
+        approved=True,
+    )
+    brand_new = Event(
+        id="evt_new",
+        owner_id="owner",
+        participants_ids=["owner"],
+        title="Brand New",
+        description="desc",
+        location="Russia, Innopolis",
+        datetime=now + timedelta(days=7, hours=6),  # enters window at now-6h
+        cost=0.0,
+        is_online=False,
+        approved=True,
+    )
+    db_session.add_all([already_seen, brand_new])
+    # Cursor sits between the two events' "entered the window" moments.
+    user.notifications_seen_at = now - timedelta(hours=15)
+    db_session.commit()
+
+    result = list_notifications(db=db_session, current_user=user)
+    by_title = {item.title: item.read for item in result.items}
+
+    assert by_title["Already Seen"] is True
+    assert by_title["Brand New"] is False

--- a/tests/test_seed_cities.py
+++ b/tests/test_seed_cities.py
@@ -1,0 +1,93 @@
+"""Tests for scripts/seed_cities.py.
+
+Confirms the script actually loads data (not just that it doesn't crash),
+that it's safe to re-run, and that the CSV shipped for production
+(scripts/data/worldcities.csv) is valid and loads end-to-end.
+"""
+from app.models.cities import City
+from app.models.email_verification import (
+    EmailVerification,  # noqa: F401 — registers relationship
+)
+from app.models.users import Admin, Alumni  # noqa: F401 — registers FK targets
+from scripts.seed_cities import CSV_PATH, seed_cities
+
+
+def _write_csv(tmp_path, rows):
+    path = tmp_path / "cities.csv"
+    with path.open("w", encoding="utf-8") as f:
+        f.write("city,lat,lng,country\n")
+        for city, lat, lng, country in rows:
+            f.write(f"{city},{lat},{lng},{country}\n")
+    return path
+
+
+def test_seed_cities_inserts_rows(db_session, tmp_path):
+    csv_path = _write_csv(
+        tmp_path,
+        [
+            ("Kazan", 55.7964, 49.1089, "Russia"),
+            ("Berlin", 52.52, 13.405, "Germany"),
+        ],
+    )
+
+    inserted = seed_cities(db_session, csv_path=csv_path)
+
+    assert inserted == 3  # 2 from the CSV + Innopolis (always added)
+    cities = {(c.city, c.country) for c in db_session.query(City)}
+    assert ("Kazan", "Russia") in cities
+    assert ("Berlin", "Germany") in cities
+    assert ("Innopolis", "Russia") in cities
+
+
+def test_seed_cities_is_idempotent(db_session, tmp_path):
+    csv_path = _write_csv(tmp_path, [("Kazan", 55.7964, 49.1089, "Russia")])
+
+    first_run = seed_cities(db_session, csv_path=csv_path)
+    second_run = seed_cities(db_session, csv_path=csv_path)
+
+    assert first_run == 2  # Kazan + Innopolis
+    assert second_run == 0
+    assert db_session.query(City).count() == 2
+
+
+def test_seed_cities_dedupes_duplicate_rows_in_csv(db_session, tmp_path):
+    csv_path = _write_csv(
+        tmp_path,
+        [
+            ("Kazan", 55.7964, 49.1089, "Russia"),
+            ("Kazan", 55.7964, 49.1089, "Russia"),
+        ],
+    )
+
+    inserted = seed_cities(db_session, csv_path=csv_path)
+
+    assert inserted == 2  # one Kazan row (duplicate dropped) + Innopolis
+    assert db_session.query(City).filter(City.city == "Kazan").count() == 1
+
+
+def test_seed_cities_skips_rows_with_bad_coordinates(db_session, tmp_path):
+    path = tmp_path / "cities.csv"
+    path.write_text(
+        "city,lat,lng,country\nBadRow,not-a-number,49.1089,Russia\n",
+        encoding="utf-8",
+    )
+
+    inserted = seed_cities(db_session, csv_path=path)
+
+    assert inserted == 1  # only Innopolis; the malformed row is skipped
+    assert db_session.query(City).filter(City.city == "BadRow").count() == 0
+
+
+def test_production_csv_loads_successfully(db_session):
+    """Exercises the actual dataset shipped for production, not a fixture."""
+    assert CSV_PATH.exists(), f"production seed data missing at {CSV_PATH}"
+
+    inserted = seed_cities(db_session)
+
+    # The real dataset has tens of thousands of cities; a low bar here
+    # just confirms the file parsed and loaded rather than silently no-op'ing.
+    assert inserted > 1000
+    assert db_session.query(City).filter(
+        City.city == "Innopolis", City.country == "Russia"
+    ).count() == 1
+    assert db_session.query(City).filter(City.city == "Tokyo").count() == 1


### PR DESCRIPTION
## Summary
- City search/autocomplete (`/cities/search`, `/cities/coordinates`) previously returned nothing in any fresh environment — the `cities` table had a migration but nothing populated it. `scripts/seed_cities.py` loads a bundled world-cities dataset idempotently and runs automatically on backend startup, so this works everywhere without a manual step.
- Adds `GET /notifications` and `GET /notifications/unread-count`: surfaces approved events within ~7 days that are near the requesting alumnus — same profile city (Innopolis/Kazan treated as one city), or any online event regardless of location. Excludes the event's own owner/participants.
- Read/unread state uses a single per-user cursor (`Alumni.notifications_seen_at`) instead of a materialized per-(user, event) table — computed live at request time, no scheduled job required. A match persists in the list once it enters the window, including after the event has occurred, so the same history shows up across sessions.

Closes #142