### PR TITLE
ci(backend): gate deploys on the smoke test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,3 +102,26 @@ jobs:
       SERVER_HOST: ${{ secrets.SERVER_HOST }}
       SERVER_USER: ${{ secrets.SERVER_USER }}
       SERVER_SSH_KEY: ${{ secrets.SERVER_SSH_KEY }}
+
+  # Verify the deploy actually serves traffic. A deploy step exiting 0 only means
+  # the SSH script ran — production once sat with a dead Docker daemon while runs
+  # were still reported as successful.
+  smoke-testing:
+    needs: deploy-testing
+    uses: iu-alumni/iu-alumni-infra/.github/workflows/smoke-test.yml@main
+    with:
+      environment: testing
+    secrets:
+      SERVER_HOST: ${{ secrets.SERVER_HOST }}
+      SERVER_USER: ${{ secrets.SERVER_USER }}
+      SERVER_SSH_KEY: ${{ secrets.SERVER_SSH_KEY }}
+
+  smoke-production:
+    needs: deploy-production
+    uses: iu-alumni/iu-alumni-infra/.github/workflows/smoke-test.yml@main
+    with:
+      environment: production
+    secrets:
+      SERVER_HOST: ${{ secrets.SERVER_HOST }}
+      SERVER_USER: ${{ secrets.SERVER_USER }}
+      SERVER_SSH_KEY: ${{ secrets.SERVER_SSH_KEY }}


### PR DESCRIPTION
A deploy step exiting 0 only proves the SSH script ran — it says nothing about whether the app serves traffic. Production recently sat with a dead Docker daemon and no `.env` while deploy runs were still reported green.

Chains `iu-alumni-infra/.github/workflows/smoke-test.yml` after each deploy (testing and production), so a deploy that doesn't actually serve traffic fails visibly instead of looking successful.

The smoke test asserts Swarm replica counts, every vhost through nginx, and the backend proxy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)