### PR TITLE
test(backend): measure coverage and fail on an empty test run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,8 +37,11 @@ jobs:
       - name: Lint with ruff
         run: ruff check .
 
+      # pytest-cov is already a dependency but coverage was never measured.
+      # Dropped the `|| [ $? -eq 5 ]` escape hatch: exit 5 means "no tests were
+      # collected", and with a populated tests/ that is a broken run, not a pass.
       - name: Run pytest
-        run: pytest --tb=short -q || [ $? -eq 5 ]
+        run: pytest --tb=short -q --cov=app --cov-report=term-missing:skip-covered
 
   build-image:
     needs: validate


### PR DESCRIPTION
Two small CI gaps:

**1. Coverage was never measured.** `pytest-cov>=4.0.0` is already in `requirements-test.txt`, but the pytest step never used it — so there's no signal about which modules are untested. Now reports `--cov=app --cov-report=term-missing:skip-covered`.

**2. `|| [ $? -eq 5 ]` swallowed empty runs.** Exit code 5 means *pytest collected no tests*. With 23 test files in `tests/`, that state means something is broken (bad import, wrong rootdir) — not a pass. Same class of escape hatch as the `|| true` recently removed from the mobile analyzer step.

This PR is deliberately just the measurement. Once CI prints the baseline I'll follow up with a `--cov-fail-under` ratchet and tests for the least-covered modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)