### PR TITLE
test(backend): cover admin creation and Telegram account linking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
       # Dropped the `|| [ $? -eq 5 ]` escape hatch: exit 5 means "no tests were
       # collected", and with a populated tests/ that is a broken run, not a pass.
       - name: Run pytest
-        run: pytest --tb=short -q --cov=app --cov-report=term-missing:skip-covered --cov-fail-under=82
+        run: pytest --tb=short -q --cov=app --cov-report=term-missing:skip-covered --cov-fail-under=84
 
   build-image:
     needs: validate

--- a/tests/test_add_admin.py
+++ b/tests/test_add_admin.py
@@ -1,0 +1,118 @@
+"""Tests for creating admin accounts.
+
+This is the highest-privilege operation in the app — it mints an account that can
+ban users, delete alumni and create further admins — so the guard against
+non-admins calling it, and the password never being stored in the clear, are the
+things that matter.
+"""
+
+import uuid
+
+from fastapi import HTTPException
+import pytest
+
+from app.api.routes.authentication.add_admin import add_admin
+from app.core.security import verify_password
+from app.models.users import Admin, Alumni
+from app.schemas.auth import AdminCreateRequest
+
+
+def _admin(email: str = "admin@innopolis.university") -> Admin:
+    return Admin(id=str(uuid.uuid4()), email=email, hashed_password="hash")
+
+
+def _alumni() -> Alumni:
+    return Alumni(
+        id=str(uuid.uuid4()),
+        email="ada@innopolis.university",
+        hashed_password="hash",
+        first_name="Ada",
+        last_name="Lovelace",
+        graduation_year="2024",
+    )
+
+
+def test_alumni_cannot_create_an_admin(db_session):
+    with pytest.raises(HTTPException) as exc:
+        add_admin(
+            AdminCreateRequest(email="new@innopolis.university", password="Passw0rd!"),
+            db=db_session,
+            current_user=_alumni(),
+        )
+
+    assert exc.value.status_code == 403
+    # Privilege escalation guard: nothing may be created by a rejected caller.
+    assert db_session.query(Admin).count() == 0
+
+
+def test_admin_can_create_another_admin(db_session):
+    creator = _admin()
+    db_session.add(creator)
+    db_session.commit()
+
+    result = add_admin(
+        AdminCreateRequest(email="new@innopolis.university", password="Passw0rd!"),
+        db=db_session,
+        current_user=creator,
+    )
+
+    assert result["email"] == "new@innopolis.university"
+    created = db_session.query(Admin).filter_by(email="new@innopolis.university").one()
+    assert created.id
+
+
+def test_created_admin_password_is_hashed(db_session):
+    creator = _admin()
+    db_session.add(creator)
+    db_session.commit()
+
+    add_admin(
+        AdminCreateRequest(email="new@innopolis.university", password="Passw0rd!"),
+        db=db_session,
+        current_user=creator,
+    )
+
+    created = db_session.query(Admin).filter_by(email="new@innopolis.university").one()
+    # Never stored in the clear, and the hash must actually validate.
+    assert created.hashed_password != "Passw0rd!"
+    assert verify_password("Passw0rd!", created.hashed_password)
+
+
+def test_duplicate_admin_email_is_rejected(db_session):
+    creator = _admin()
+    existing = _admin("taken@innopolis.university")
+    db_session.add_all([creator, existing])
+    db_session.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        add_admin(
+            AdminCreateRequest(email="taken@innopolis.university", password="Passw0rd!"),
+            db=db_session,
+            current_user=creator,
+        )
+
+    assert exc.value.status_code == 400
+    # The existing admin's credentials must not be overwritten by a re-create.
+    assert db_session.query(Admin).filter_by(email="taken@innopolis.university").count() == 1
+    db_session.refresh(existing)
+    assert existing.hashed_password == "hash"
+
+
+def test_new_admins_get_distinct_ids(db_session):
+    creator = _admin()
+    db_session.add(creator)
+    db_session.commit()
+
+    add_admin(
+        AdminCreateRequest(email="one@innopolis.university", password="Passw0rd!"),
+        db=db_session,
+        current_user=creator,
+    )
+    add_admin(
+        AdminCreateRequest(email="two@innopolis.university", password="Passw0rd!"),
+        db=db_session,
+        current_user=creator,
+    )
+
+    ids = {a.id for a in db_session.query(Admin).all()}
+    assert len(ids) == 3

--- a/tests/test_telegram_verify.py
+++ b/tests/test_telegram_verify.py
@@ -1,0 +1,239 @@
+"""Tests for linking a Telegram account to an alumni account.
+
+Confirming this link flips `is_telegram_verified`, which is exactly the flag the
+Telegram OTP login path requires. A weak link here is an account-takeover route,
+so single use, expiry and the pre-checks before a token is ever issued are the
+behaviours under test.
+"""
+
+from datetime import UTC, datetime, timedelta
+import uuid
+
+from fastapi import HTTPException
+import pytest
+
+from app.api.routes.authentication.telegram_verify import (
+    telegram_verify_confirm,
+    telegram_verify_request,
+)
+from app.models.telegram import TelegramUser
+from app.models.telegram_verify_token import TelegramVerifyToken
+from app.models.users import Admin, Alumni
+
+
+ALIAS = "ada_lovelace"
+
+
+def _now() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+def _alumni(
+    *, telegram_alias: str | None = ALIAS, is_telegram_verified: bool = False
+) -> Alumni:
+    return Alumni(
+        id=str(uuid.uuid4()),
+        email=f"{uuid.uuid4().hex[:8]}@innopolis.university",
+        hashed_password="hash",
+        first_name="Ada",
+        last_name="Lovelace",
+        graduation_year="2024",
+        telegram_alias=telegram_alias,
+        is_telegram_verified=is_telegram_verified,
+    )
+
+
+def _token(alumni_id: str, **overrides) -> TelegramVerifyToken:
+    values = {
+        "id": str(uuid.uuid4()),
+        "alumni_id": alumni_id,
+        "token": str(uuid.uuid4()),
+        "expires_at": _now() + timedelta(hours=24),
+        "used": False,
+        "created_at": _now(),
+    }
+    values.update(overrides)
+    return TelegramVerifyToken(**values)
+
+
+def _patch_email(mocker, *, sent: bool = True):
+    return mocker.patch(
+        "app.api.routes.authentication.telegram_verify.send_telegram_verification_email",
+        return_value=sent,
+    )
+
+
+# ── request ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_request_rejects_admin_accounts(db_session, mocker):
+    _patch_email(mocker)
+    admin = Admin(id=str(uuid.uuid4()), email="admin@innopolis.university")
+
+    with pytest.raises(HTTPException) as exc:
+        await telegram_verify_request(db=db_session, current_user=admin)
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_request_requires_an_alias(db_session, mocker):
+    send = _patch_email(mocker)
+    user = _alumni(telegram_alias=None)
+    db_session.add(user)
+    db_session.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        await telegram_verify_request(db=db_session, current_user=user)
+
+    assert exc.value.status_code == 400
+    assert db_session.query(TelegramVerifyToken).count() == 0
+    send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_request_requires_the_bot_to_be_started(db_session, mocker):
+    send = _patch_email(mocker)
+    user = _alumni()
+    db_session.add(user)
+    db_session.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        await telegram_verify_request(db=db_session, current_user=user)
+
+    assert exc.value.status_code == 400
+    assert db_session.query(TelegramVerifyToken).count() == 0
+    send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_request_issues_a_token_and_emails_the_link(db_session, mocker):
+    send = _patch_email(mocker)
+    user = _alumni()
+    db_session.add_all([user, TelegramUser(alias=ALIAS, chat_id=4242)])
+    db_session.commit()
+
+    await telegram_verify_request(db=db_session, current_user=user)
+
+    token = db_session.query(TelegramVerifyToken).filter_by(alumni_id=user.id).one()
+    assert token.used is False
+    assert token.expires_at > _now()
+    # The link goes to the account's email, not to Telegram — that is the point
+    # of the flow: it proves control of both channels.
+    assert send.call_args.kwargs["email"] == user.email
+    assert token.token in send.call_args.kwargs["verify_link"]
+
+
+@pytest.mark.asyncio
+async def test_request_invalidates_previous_unused_tokens(db_session, mocker):
+    _patch_email(mocker)
+    user = _alumni()
+    db_session.add_all([user, TelegramUser(alias=ALIAS, chat_id=4242)])
+    db_session.commit()
+    stale = _token(user.id)
+    stale_value = stale.token
+    db_session.add(stale)
+    db_session.commit()
+
+    await telegram_verify_request(db=db_session, current_user=user)
+
+    remaining = db_session.query(TelegramVerifyToken).all()
+    assert len(remaining) == 1
+    assert remaining[0].token != stale_value
+
+
+@pytest.mark.asyncio
+async def test_request_surfaces_email_failure(db_session, mocker):
+    _patch_email(mocker, sent=False)
+    user = _alumni()
+    db_session.add_all([user, TelegramUser(alias=ALIAS, chat_id=4242)])
+    db_session.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        await telegram_verify_request(db=db_session, current_user=user)
+
+    assert exc.value.status_code == 500
+
+
+# ── confirm ──────────────────────────────────────────────────────────────────
+
+
+def test_confirm_verifies_the_account(db_session):
+    user = _alumni()
+    db_session.add(user)
+    db_session.commit()
+    token = _token(user.id)
+    db_session.add(token)
+    db_session.commit()
+
+    response = telegram_verify_confirm(token=token.token, db=db_session)
+
+    assert response.status_code == 200
+    db_session.refresh(user)
+    db_session.refresh(token)
+    # This flag is what unlocks Telegram OTP login.
+    assert user.is_telegram_verified is True
+    assert token.used is True
+
+
+def test_confirm_rejects_unknown_token(db_session):
+    response = telegram_verify_confirm(token="does-not-exist", db=db_session)
+
+    assert response.status_code == 400
+
+
+def test_confirm_rejects_a_used_token(db_session):
+    user = _alumni()
+    db_session.add(user)
+    db_session.commit()
+    token = _token(user.id, used=True)
+    db_session.add(token)
+    db_session.commit()
+
+    response = telegram_verify_confirm(token=token.token, db=db_session)
+
+    assert response.status_code == 400
+    db_session.refresh(user)
+    assert user.is_telegram_verified is False
+
+
+def test_confirm_rejects_an_expired_token(db_session):
+    user = _alumni()
+    db_session.add(user)
+    db_session.commit()
+    token = _token(user.id, expires_at=_now() - timedelta(minutes=1))
+    db_session.add(token)
+    db_session.commit()
+
+    response = telegram_verify_confirm(token=token.token, db=db_session)
+
+    assert response.status_code == 400
+    db_session.refresh(user)
+    assert user.is_telegram_verified is False
+
+
+def test_confirm_handles_a_deleted_account(db_session):
+    token = _token(str(uuid.uuid4()))
+    db_session.add(token)
+    db_session.commit()
+
+    response = telegram_verify_confirm(token=token.token, db=db_session)
+
+    # The alumnus was deleted after the link was sent.
+    assert response.status_code == 404
+
+
+def test_confirm_link_cannot_be_replayed(db_session):
+    user = _alumni()
+    db_session.add(user)
+    db_session.commit()
+    token = _token(user.id)
+    db_session.add(token)
+    db_session.commit()
+
+    telegram_verify_confirm(token=token.token, db=db_session)
+    second = telegram_verify_confirm(token=token.token, db=db_session)
+
+    # A forwarded or leaked link must not re-verify later.
+    assert second.status_code == 400


### PR DESCRIPTION
Continues from #159, but picked by **risk** rather than by coverage number — these are the two highest-stakes gaps left.

## add_admin (50% → 100%)

Mints the highest-privilege account in the app: one that can ban users, delete alumni, and create further admins.

- an alumni caller gets 403 **and no admin row is created**
- a duplicate email is rejected **without overwriting the existing admin's credentials** (a re-create must not become a silent password reset)
- the password is stored hashed, not in the clear, and the hash actually validates
- created admins get distinct ids

## telegram_verify (38% → 100%)

Confirming this link flips `is_telegram_verified` — the exact flag the Telegram OTP login path (#155) requires — so a weak link here is an account-takeover route.

**request** — admin accounts, a missing alias, and an un-started bot are all rejected *before* a token is issued or mail is sent; previous unused tokens are invalidated so only the newest link works; the link is emailed to the account address (the flow's whole point is proving control of *both* channels); email failure surfaces as 500.

**confirm** — unknown, already-used and expired links are rejected **and `is_telegram_verified` stays false**; a token whose alumnus was deleted returns 404 instead of erroring; and a link cannot be replayed, so a forwarded or leaked email can't re-verify later.

Total **83% → 85%**, 373 tests, ruff clean. Ratchets `--cov-fail-under` 82 → 84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)