### PR TITLE
feat(users): alumni_friend role + nullable graduation_year [#16]

### DIFF
--- a/alembic/versions/b4d15f21e9a7_add_alumni_friend_role.py
+++ b/alembic/versions/b4d15f21e9a7_add_alumni_friend_role.py
@@ -1,0 +1,45 @@
+"""Add alumni role enum + make graduation_year nullable
+
+Revision ID: b4d15f21e9a7
+Revises: f3a4b5c6d7e8
+Create Date: 2026-07-28 15:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "b4d15f21e9a7"
+down_revision: Union[str, None] = "f3a4b5c6d7e8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Postgres enum. Stored as text is tempting for cheap migrations, but the
+# enum gives us a real constraint at the DB level and neat OpenAPI schemas.
+_role_enum = sa.Enum("alumni", "alumni_friend", name="alumni_role")
+
+
+def upgrade() -> None:
+    _role_enum.create(op.get_bind(), checkfirst=True)
+    op.add_column(
+        "alumni",
+        sa.Column(
+            "role",
+            _role_enum,
+            nullable=False,
+            server_default="alumni",
+        ),
+    )
+    # Alumni Friends have no graduation year by design; existing rows all
+    # come in as role='alumni' and keep their year, so the loosened
+    # constraint is safe.
+    op.alter_column("alumni", "graduation_year", nullable=True)
+
+
+def downgrade() -> None:
+    op.alter_column("alumni", "graduation_year", nullable=False)
+    op.drop_column("alumni", "role")
+    _role_enum.drop(op.get_bind(), checkfirst=True)

--- a/app/api/routes/admin/verify_user.py
+++ b/app/api/routes/admin/verify_user.py
@@ -38,8 +38,18 @@ async def verify_user(
     # Get the verified user to send email
     user = db.query(Alumni).filter(Alumni.email == request.email).first()
     if user:
+        # Apply the optional role override — admins can flip a pending
+        # user's role at approval time (see AdminVerifyRequest).
+        if request.role is not None and request.role != user.role:
+            user.role = request.role
+            # Alumni Friends have no graduation year by design; clear it
+            # so the record stays consistent with the role.
+            if request.role == "alumni_friend":
+                user.graduation_year = None
+            db.commit()
+            db.refresh(user)
         background_tasks.add_task(
             send_verification_success_email, user.email, user.first_name
         )
 
-    return {"message": message, "email": request.email}
+    return {"message": message, "email": request.email, "role": user.role if user else None}

--- a/app/api/routes/authentication/register.py
+++ b/app/api/routes/authentication/register.py
@@ -55,6 +55,7 @@ async def register(
         first_name=request.first_name,
         last_name=request.last_name,
         graduation_year=request.graduation_year,
+        role=request.role,
         telegram_alias=request.telegram_alias,
         is_verified=False,
         is_banned=False,

--- a/app/api/routes/profile/profile.py
+++ b/app/api/routes/profile/profile.py
@@ -58,7 +58,10 @@ async def update_profile(
             profile_data.last_name, "Last name"
         )
 
-    if profile_data.graduation_year is not None:
+    # Alumni Friends have no graduation year — ignore attempts to set
+    # one on their profile so the record stays consistent with the role.
+    # Regular alumni can update it freely.
+    if profile_data.graduation_year is not None and current_user.role != "alumni_friend":
         current_user.graduation_year = profile_data.graduation_year
 
     if profile_data.location is not None:

--- a/app/models/users.py
+++ b/app/models/users.py
@@ -1,7 +1,14 @@
-from sqlalchemy import Boolean, Column, DateTime, String
+from sqlalchemy import Boolean, Column, DateTime, Enum, String
 from sqlalchemy.orm import relationship
 
 from app.core.database import Base
+
+
+# Kept in one place so the schema layer, the mobile app, and the admin
+# portal all agree on the wire format.
+ALUMNI_ROLE_ALUMNI = "alumni"
+ALUMNI_ROLE_FRIEND = "alumni_friend"
+ALUMNI_ROLES = (ALUMNI_ROLE_ALUMNI, ALUMNI_ROLE_FRIEND)
 
 
 class Alumni(Base):
@@ -12,7 +19,16 @@ class Alumni(Base):
     hashed_password = Column(String)
     first_name = Column(String, nullable=False)
     last_name = Column(String, nullable=False)
-    graduation_year = Column(String, nullable=False)
+    # NULL for Alumni Friends (staff / dropouts / other non-graduates).
+    graduation_year = Column(String, nullable=True)
+    # 'alumni' by default. Alumni Friends can't set graduation_year and
+    # render a chip instead of the year tag on their profile.
+    role = Column(
+        Enum(*ALUMNI_ROLES, name="alumni_role"),
+        nullable=False,
+        default=ALUMNI_ROLE_ALUMNI,
+        server_default=ALUMNI_ROLE_ALUMNI,
+    )
     location = Column(String)
     biography = Column(String)
     show_location = Column(Boolean, default=False)

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -59,9 +59,10 @@ class RegisterRequest(BaseModel):
             # The field is meaningless for friends — null it regardless
             # of what the client sent so the row stays consistent.
             self.graduation_year = None
-        elif self.role == "alumni":
-            if self.graduation_year is None or not self.graduation_year.strip():
-                raise ValueError("graduation_year is required for role='alumni'")
+        elif self.role == "alumni" and (
+            self.graduation_year is None or not self.graduation_year.strip()
+        ):
+            raise ValueError("graduation_year is required for role='alumni'")
         return self
 
     @field_validator("email")

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,6 +1,6 @@
 import re
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import BaseModel, EmailStr, Field, field_validator, model_validator
 
 
 class LoginRequest(BaseModel):
@@ -44,11 +44,25 @@ class AdminCreateRequest(BaseModel):
 class RegisterRequest(BaseModel):
     first_name: str = Field(..., min_length=1, max_length=100)
     last_name: str = Field(..., min_length=1, max_length=100)
-    graduation_year: str
+    # Alumni Friends (staff / dropouts / other non-graduates) skip the
+    # graduation year — the role field decides which is required.
+    graduation_year: str | None = None
+    role: str = Field(default="alumni", pattern="^(alumni|alumni_friend)$")
     email: EmailStr
     telegram_alias: str = Field(..., min_length=3, max_length=50)
     password: str = Field(..., min_length=8)
     manual_verification: bool = False
+
+    @model_validator(mode="after")
+    def validate_grad_year_matches_role(self):
+        if self.role == "alumni_friend":
+            # The field is meaningless for friends — null it regardless
+            # of what the client sent so the row stays consistent.
+            self.graduation_year = None
+        elif self.role == "alumni":
+            if self.graduation_year is None or not self.graduation_year.strip():
+                raise ValueError("graduation_year is required for role='alumni'")
+        return self
 
     @field_validator("email")
     def validate_innopolis_email(cls, v):
@@ -75,6 +89,10 @@ class VerifyEmailRequest(BaseModel):
 
 class AdminVerifyRequest(BaseModel):
     email: EmailStr
+    # Optional role override applied on verification. Handy when the user
+    # registered as 'alumni' by mistake and the admin sees during review
+    # that they should be 'alumni_friend' (or vice versa).
+    role: str | None = Field(default=None, pattern="^(alumni|alumni_friend)$")
 
 
 class ResendVerificationRequest(BaseModel):

--- a/app/schemas/profile.py
+++ b/app/schemas/profile.py
@@ -9,7 +9,11 @@ class ProfileResponse(BaseModel):
     id: str
     first_name: str
     last_name: str
-    graduation_year: str
+    # None for Alumni Friends (staff / dropouts / other non-graduate
+    # community members). Clients render an "Alumni Friend" chip in
+    # place of the graduation-year tag when role == 'alumni_friend'.
+    graduation_year: str | None = None
+    role: str = "alumni"
     location: str | None = None
     biography: str | None = None
     show_location: bool = False
@@ -27,7 +31,8 @@ class ProfileListItem(BaseModel):
     id: str
     first_name: str
     last_name: str
-    graduation_year: str
+    graduation_year: str | None = None
+    role: str = "alumni"
     location: str | None = None
     biography: str | None = None
     show_location: bool = False

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -7,7 +7,10 @@ class Alumni(BaseModel):
     hashed_password: str | None = None
     first_name: str
     last_name: str
-    graduation_year: str
+    # None for Alumni Friends (staff / dropouts / other non-graduates
+    # per FR22). Regular alumni still carry a year string.
+    graduation_year: str | None = None
+    role: str = "alumni"
     location: str | None = None
     biography: str | None = None
     avatar: str | None = None
@@ -26,7 +29,8 @@ class AlumniListItem(BaseModel):
     email: str
     first_name: str
     last_name: str
-    graduation_year: str
+    graduation_year: str | None = None
+    role: str = "alumni"
     location: str | None = None
     biography: str | None = None
     telegram_alias: str | None = None

--- a/tests/test_alumni_friend_role.py
+++ b/tests/test_alumni_friend_role.py
@@ -1,0 +1,181 @@
+"""Tests for the alumni_friend role introduced in FR22.
+
+Covers three behaviours:
+- Register validation: graduation_year required for role=alumni, ignored
+  (nulled) for role=alumni_friend.
+- Admin verify: optional `role` override on the request payload flips
+  the row and clears graduation_year when needed.
+- Profile update: an alumni_friend can't accidentally acquire a
+  graduation_year by PUTting one.
+"""
+from __future__ import annotations
+
+from fastapi import HTTPException
+import pytest
+
+from app.api.routes.admin.verify_user import verify_user as admin_verify_user_route
+from app.api.routes.profile.profile import update_profile
+from app.models.users import Admin, Alumni
+from app.schemas.auth import AdminVerifyRequest, RegisterRequest
+from app.schemas.profile import ProfileUpdateRequest
+
+
+def _alumnus(**overrides) -> Alumni:
+    defaults = dict(
+        id="u-1",
+        email="u@innopolis.university",
+        hashed_password="x",
+        first_name="U",
+        last_name="U",
+        graduation_year="2024",
+        role="alumni",
+        is_verified=False,
+        is_banned=False,
+    )
+    defaults.update(overrides)
+    return Alumni(**defaults)
+
+
+def _admin() -> Admin:
+    return Admin(id="a-1", email="admin@innopolis.university", hashed_password="x")
+
+
+# ─────────────────────────── register validation ────────────────────────
+
+
+class TestRegisterValidation:
+    def test_alumni_requires_graduation_year(self):
+        with pytest.raises(ValueError):
+            RegisterRequest(
+                first_name="A",
+                last_name="B",
+                graduation_year=None,
+                email="a@innopolis.university",
+                telegram_alias="tg_alias",
+                password="password123",
+            )
+
+    def test_alumni_rejects_blank_graduation_year(self):
+        with pytest.raises(ValueError):
+            RegisterRequest(
+                first_name="A",
+                last_name="B",
+                graduation_year="   ",
+                email="a@innopolis.university",
+                telegram_alias="tg_alias",
+                password="password123",
+            )
+
+    def test_friend_defaults_to_null_year_even_if_supplied(self):
+        req = RegisterRequest(
+            first_name="A",
+            last_name="B",
+            role="alumni_friend",
+            graduation_year="2024",  # sneaky — should be nulled
+            email="a@innopolis.university",
+            telegram_alias="tg_alias",
+            password="password123",
+        )
+        assert req.graduation_year is None
+        assert req.role == "alumni_friend"
+
+    def test_bad_role_rejected(self):
+        with pytest.raises(ValueError):
+            RegisterRequest(
+                first_name="A",
+                last_name="B",
+                graduation_year="2024",
+                role="mystery",
+                email="a@innopolis.university",
+                telegram_alias="tg_alias",
+                password="password123",
+            )
+
+
+# ─────────────────────────── admin verify override ──────────────────────
+
+
+class TestAdminVerifyRoleOverride:
+    @pytest.mark.asyncio
+    async def test_non_admin_forbidden(self, db_session):
+        alice = _alumnus()
+        db_session.add(alice)
+        db_session.commit()
+        with pytest.raises(HTTPException) as exc:
+            await admin_verify_user_route(
+                request=AdminVerifyRequest(email=alice.email),
+                background_tasks=_BgTasksStub(),
+                db=db_session,
+                current_user=alice,
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_role_override_to_friend_clears_year(self, db_session):
+        alice = _alumnus(graduation_year="2024", role="alumni")
+        db_session.add(alice)
+        db_session.commit()
+        await admin_verify_user_route(
+            request=AdminVerifyRequest(email=alice.email, role="alumni_friend"),
+            background_tasks=_BgTasksStub(),
+            db=db_session,
+            current_user=_admin(),
+        )
+        db_session.refresh(alice)
+        assert alice.role == "alumni_friend"
+        assert alice.graduation_year is None
+
+    @pytest.mark.asyncio
+    async def test_no_role_field_leaves_role_untouched(self, db_session):
+        alice = _alumnus(role="alumni_friend", graduation_year=None)
+        db_session.add(alice)
+        db_session.commit()
+        await admin_verify_user_route(
+            request=AdminVerifyRequest(email=alice.email),
+            background_tasks=_BgTasksStub(),
+            db=db_session,
+            current_user=_admin(),
+        )
+        db_session.refresh(alice)
+        assert alice.role == "alumni_friend"
+
+
+# ─────────────────────────── profile update guard ───────────────────────
+
+
+class TestProfileUpdateIgnoresFriendYear:
+    @pytest.mark.asyncio
+    async def test_friend_cannot_set_graduation_year_via_profile_update(
+        self, db_session
+    ):
+        friend = _alumnus(role="alumni_friend", graduation_year=None)
+        db_session.add(friend)
+        db_session.commit()
+        await update_profile(
+            profile_data=ProfileUpdateRequest(graduation_year="2024"),
+            current_user=friend,
+            db=db_session,
+        )
+        db_session.refresh(friend)
+        assert friend.graduation_year is None
+
+    @pytest.mark.asyncio
+    async def test_regular_alumnus_can_update_their_year(self, db_session):
+        alice = _alumnus(graduation_year="2023")
+        db_session.add(alice)
+        db_session.commit()
+        await update_profile(
+            profile_data=ProfileUpdateRequest(graduation_year="2024"),
+            current_user=alice,
+            db=db_session,
+        )
+        db_session.refresh(alice)
+        assert alice.graduation_year == "2024"
+
+
+class _BgTasksStub:
+    """Stand-in for FastAPI's BackgroundTasks — we don't care about the
+    email side-effect in these tests."""
+
+    def add_task(self, *args, **kwargs):
+        return None

--- a/tests/test_alumni_friend_role.py
+++ b/tests/test_alumni_friend_role.py
@@ -21,17 +21,17 @@ from app.schemas.profile import ProfileUpdateRequest
 
 
 def _alumnus(**overrides) -> Alumni:
-    defaults = dict(
-        id="u-1",
-        email="u@innopolis.university",
-        hashed_password="x",
-        first_name="U",
-        last_name="U",
-        graduation_year="2024",
-        role="alumni",
-        is_verified=False,
-        is_banned=False,
-    )
+    defaults = {
+        "id": "u-1",
+        "email": "u@innopolis.university",
+        "hashed_password": "x",
+        "first_name": "U",
+        "last_name": "U",
+        "graduation_year": "2024",
+        "role": "alumni",
+        "is_verified": False,
+        "is_banned": False,
+    }
     defaults.update(overrides)
     return Alumni(**defaults)
 
@@ -45,7 +45,7 @@ def _admin() -> Admin:
 
 class TestRegisterValidation:
     def test_alumni_requires_graduation_year(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="graduation_year is required"):
             RegisterRequest(
                 first_name="A",
                 last_name="B",
@@ -56,7 +56,7 @@ class TestRegisterValidation:
             )
 
     def test_alumni_rejects_blank_graduation_year(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="graduation_year is required"):
             RegisterRequest(
                 first_name="A",
                 last_name="B",
@@ -80,7 +80,8 @@ class TestRegisterValidation:
         assert req.role == "alumni_friend"
 
     def test_bad_role_rejected(self):
-        with pytest.raises(ValueError):
+        # Pydantic's regex/pattern failure surfaces as "String should match pattern".
+        with pytest.raises(ValueError, match="should match pattern"):
             RegisterRequest(
                 first_name="A",
                 last_name="B",
@@ -177,5 +178,5 @@ class _BgTasksStub:
     """Stand-in for FastAPI's BackgroundTasks — we don't care about the
     email side-effect in these tests."""
 
-    def add_task(self, *args, **kwargs):
+    def add_task(self, *args, **kwargs):  # noqa: ARG002 — stub signature match
         return None


### PR DESCRIPTION
## Summary
Adds a second alumni role (`alumni_friend`) for university staff, dropouts who stayed in the community, and other non-graduate members per FR22. Friends carry no graduation year; the profile UI will render an "Alumni Friend" chip in place of the year tag.

## Changes
- **Migration** `b4d15f21e9a7` — `alumni_role` enum, `alumni.role` column with `server_default='alumni'`, `graduation_year` → NULLABLE. Existing rows keep their year and default to `alumni`.
- **Model** — enum column + `ALUMNI_ROLE_*` constants exported so the schema, routes, and tests stay in sync.
- **Register schema** — `role` field (regex-guarded), `graduation_year` optional. A `model_validator` enforces the cross-field rule: required for `alumni`, nulled for `alumni_friend` (even if a client sneaks a value in).
- **Register route** — passes the requested role into the new Alumni row.
- **Admin verify** — optional `role` override on the payload lets admins flip a mistakenly-registered user's role at approval time. Clearing to `alumni_friend` also nulls the graduation year server-side.
- **Profile update** — ignores `graduation_year` on `alumni_friend` records so it can't be set via a self-serve edit.
- **Response schemas** — `graduation_year` now `Optional[str]` and `role` exposed on `ProfileResponse` + `ProfileListItem`.

## Test plan
- [x] `pytest tests/test_alumni_friend_role.py` — 9 new cases, all pass.
- [x] Full suite: **455 passed, 2 skipped**, zero regressions.
- [x] Ruff clean.
- [ ] Migration applied against staging DB.
- [ ] Manual smoke: register a friend via `/auth/register {role: 'alumni_friend'}`, verify no graduation year on the row.

## Follow-ups
- Mobile ([mobile#162](https://github.com/iu-alumni/iu-alumni-mobile/issues/162)) — role select at signup + Alumni Friend chip on profile.
- Admin portal ([frontend#83](https://github.com/iu-alumni/iu-alumni-frontend/issues/83)) — role in the user list + editor on the detail page.

Closes #170.