### PR TITLE
hotfix(alembic): merge projects and alumni migration heads

### DIFF
--- a/alembic/versions/c5d6e7f8a9b0_merge_projects_and_alumni_heads.py
+++ b/alembic/versions/c5d6e7f8a9b0_merge_projects_and_alumni_heads.py
@@ -1,0 +1,25 @@
+"""Merge projects and alumni-role migration heads.
+
+Revision ID: c5d6e7f8a9b0
+Revises: 8c4d2b1a6f3e, b4d15f21e9a7
+Create Date: 2026-07-30 05:30:00.000000
+"""
+
+from collections.abc import Sequence
+
+
+revision: str = "c5d6e7f8a9b0"
+down_revision: str | tuple[str, str] | None = (
+    "8c4d2b1a6f3e",
+    "b4d15f21e9a7",
+)
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Join both migration branches without changing the schema."""
+
+
+def downgrade() -> None:
+    """Split the migration graph back into its two parent heads."""


### PR DESCRIPTION
## Description

Production failed to start because Alembic detected two migration heads after PR #148. This adds a no-op merge migration joining the projects and alumni-role heads, allowing alembic upgrade head to complete normally.
The hotfix joins these two heads.

Verified with Ruff, alembic heads, and project tests.