### PR TITLE
Reduce event-list payload size

### DIFF
--- a/app/api/routes/admin/list_all_events.py
+++ b/app/api/routes/admin/list_all_events.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import and_, or_
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, defer
 
 from app.core.database import get_db
 from app.core.security import get_current_user
@@ -32,7 +32,7 @@ async def list_events(
             status_code=403, detail="You are not authorized to access this resource"
         )
 
-    query = db.query(Event)
+    query = db.query(Event).options(defer(Event.cover))
 
     if search:
         query = query.filter(Event.title.ilike(f"%{search}%"))

--- a/app/api/routes/events/list_events.py
+++ b/app/api/routes/events/list_events.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy import and_, or_
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, defer
 
 from app.core.database import get_db
 from app.core.security import get_current_user
@@ -27,7 +27,7 @@ async def list_events(
     current_user: Alumni | Admin = Depends(get_current_user),
 ):
     """List all approved events with optional title search and cursor-based pagination."""
-    query = db.query(Event).filter(Event.approved == True)
+    query = db.query(Event).options(defer(Event.cover)).filter(Event.approved == True)
 
     if search:
         query = query.filter(Event.title.ilike(f"%{search}%"))

--- a/app/schemas/event.py
+++ b/app/schemas/event.py
@@ -24,7 +24,12 @@ class Event(BaseModel):
 
 
 class EventListItem(BaseModel):
-    """Slim event schema for list responses — includes cover image."""
+    """Slim event schema for list responses.
+
+    Covers are intentionally omitted because embedding base64 images made a
+    single page several megabytes large. Clients load them from the dedicated
+    ``GET /events/{event_id}/cover`` endpoint instead.
+    """
 
     id: str
     owner_id: str
@@ -35,14 +40,11 @@ class EventListItem(BaseModel):
     datetime: datetime
     cost: float
     is_online: bool
-    cover: str | None = None
     approved: bool | None = None
 
 
 class AdminEventListItem(EventListItem):
-    """Admin event list item — includes cover for thumbnail display."""
-
-    cover: str | None = None
+    """Admin event list item; covers are loaded separately."""
 
 
 class CreateEventRequest(BaseModel):

--- a/tests/test_event_list_payload.py
+++ b/tests/test_event_list_payload.py
@@ -1,0 +1,61 @@
+"""Regression tests for the event-feed payload size.
+
+Synthetic large covers reproduce the production risk without needing a copy
+of production data.
+"""
+
+from datetime import datetime, timedelta
+
+from app.core.security import get_current_user
+from app.models.events import Event
+from app.models.users import Admin, Alumni
+
+
+EVENT_COUNT = 100
+COVER_SIZE = 250_000
+MAX_LIST_RESPONSE_SIZE = 100_000
+
+
+def test_large_covers_do_not_inflate_public_or_admin_event_lists(client, db_session):
+    owner = Alumni(
+        id="payload-owner",
+        email="payload-owner@innopolis.university",
+        first_name="Payload",
+        last_name="Owner",
+        graduation_year="2026",
+    )
+    db_session.add(owner)
+    base_time = datetime(2026, 8, 1, 12, 0)
+    db_session.add_all(
+        [
+            Event(
+                id=f"payload-event-{index:03d}",
+                owner_id=owner.id,
+                participants_ids=[],
+                title=f"Synthetic event {index}",
+                description="Synthetic payload regression event",
+                location="Innopolis",
+                datetime=base_time + timedelta(minutes=index),
+                cost=0,
+                is_online=False,
+                cover="A" * COVER_SIZE,
+                approved=True,
+            )
+            for index in range(EVENT_COUNT)
+        ]
+    )
+    db_session.commit()
+
+    client.app.dependency_overrides[get_current_user] = lambda: owner
+    public_response = client.get("/api/v1/events/?limit=100")
+
+    admin = Admin(id="payload-admin", email="payload-admin@innopolis.university")
+    client.app.dependency_overrides[get_current_user] = lambda: admin
+    admin_response = client.get("/api/v1/admin/events?limit=100")
+
+    for response in (public_response, admin_response):
+        assert response.status_code == 200
+        assert len(response.json()["items"]) == EVENT_COUNT
+        assert all("cover" not in item for item in response.json()["items"])
+        assert len(response.content) < MAX_LIST_RESPONSE_SIZE
+

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -9,7 +9,12 @@ from app.schemas.auth import (
     PasswordResetConfirmSchema,
     RegisterRequest,
 )
-from app.schemas.event import CreateEventRequest, UpdateEventRequest
+from app.schemas.event import (
+    AdminEventListItem,
+    CreateEventRequest,
+    EventListItem,
+    UpdateEventRequest,
+)
 
 
 class TestAuthSchemas:
@@ -321,6 +326,23 @@ class TestAuthSchemas:
 
 class TestEventSchemas:
     """Test cases for event schemas."""
+
+    @pytest.mark.parametrize("schema", [EventListItem, AdminEventListItem])
+    def test_event_lists_do_not_embed_base64_covers(self, schema):
+        item = schema(
+            id="event-1",
+            owner_id="owner-1",
+            participants_ids=[],
+            title="Meetup",
+            description="Description",
+            location="Innopolis",
+            datetime="2026-08-01T12:00:00",
+            cost=0,
+            is_online=False,
+            approved=True,
+        )
+
+        assert "cover" not in item.model_dump()
 
     def test_create_event_rejects_blank_required_text(self):
         """Test CreateEventRequest rejects whitespace-only text fields."""


### PR DESCRIPTION
## Summary
- Exclude covers from public and admin event lists
- Defer the cover database column
- Add a synthetic payload regression test

Closes #175 
